### PR TITLE
Merge main to dev

### DIFF
--- a/src/app/modules/private/devices/modals/device-create-edit-modal/device-create-edit-modal.component.ts
+++ b/src/app/modules/private/devices/modals/device-create-edit-modal/device-create-edit-modal.component.ts
@@ -8,7 +8,7 @@ import {
   SimpleChanges,
   OnDestroy,
   ChangeDetectionStrategy,
-  ChangeDetectorRef
+  ChangeDetectorRef,
 } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import {
@@ -23,7 +23,6 @@ import { Subject, takeUntil, finalize } from 'rxjs';
 import { DevicesService } from '../../services/devices.service';
 import { noWhitespaceValidator } from '../../../../../core/utils/form-validators.utils';
 import { toast } from 'ngx-sonner';
-
 
 @Component({
   selector: 'app-device-create-edit-modal',
@@ -198,5 +197,23 @@ export class DeviceCreateEditModalComponent
       current.barcode !== this.device.barcode ||
       current.status !== this.device.status
     );
+  }
+
+  /** Inicia el estado de carga del formulario y deshabilita los campos para evitar cambios durante la operación
+   * Detiene el estado de carga y habilita los campos del formulario después de la operación
+   * Limpia el mensaje de error para que no persista en operaciones futuras
+   * @returns void
+   */
+  startFormLoading(): void {
+    this.formLoading = true;
+    this.deviceForm.disable();
+  }
+
+  /** Detiene el estado de carga del formulario y habilita los campos para permitir cambios después de la operación
+   * @returns void
+   */
+  stopFormLoading(): void {
+    this.formLoading = false;
+    this.deviceForm.enable();
   }
 }

--- a/src/app/modules/private/devices/pages/devices/devices.component.html
+++ b/src/app/modules/private/devices/pages/devices/devices.component.html
@@ -40,7 +40,7 @@
 
   <!-- Stats resumen con iconos SVG -->
   <ng-container *ngIf="filteredStats$ | async as stats">
-    <div *ngIf="!deviceError && stats.totalDevices > 0" class="grid grid-cols-2 md:grid-cols-4 gap-6 mb-8">
+    <div *ngIf="!deviceError" class="grid grid-cols-2 md:grid-cols-4 gap-6 mb-8">
       <div class="stat shadow-md rounded-lg">
         <div class="stat-figure text-primary">
           <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
@@ -121,7 +121,7 @@
 
 
     <!-- FILTROS -->
-    <div *ngIf="!deviceError && stats.totalDevices > 0" class="flex flex-wrap gap-4 items-end mb-8 justify-start">
+    <div *ngIf="!deviceError" class="flex flex-wrap gap-4 items-end mb-8 justify-start">
       <div class="relative w-full sm:w-60">
         <input class="input input-bordered w-full pl-12 bg-white/90 shadow focus:ring-2 focus:ring-blue-400"
           placeholder="Buscar por nombre, marca o código..." [value]="search"
@@ -180,13 +180,9 @@
 
     <!-- TABLA principal de dispositivos -->
     <div *ngIf="!deviceError && stats.totalDevices > 0" class="relative">
-      <div *ngIf="loading" class="absolute inset-0 flex justify-center items-center bg-white/60 z-20">
-        <span class="loading loading-spinner loading-lg text-primary"></span>
-      </div>
-
       <ng-container *ngIf="pagedDevices$ | async as pagedDevices">
         <table class="table w-full table-zebra rounded-xl shadow-lg overflow-hidden"
-          *ngIf="!loading && pagedDevices.length > 0">
+          *ngIf="pagedDevices.length > 0">
           <thead class="bg-blue-100">
             <tr>
               <th>
@@ -265,7 +261,7 @@
         </table>
 
         <!-- Estado vacío -->
-        <div *ngIf="!loading && pagedDevices.length === 0" class="py-12 text-center opacity-80">
+        <div *ngIf="pagedDevices.length === 0" class="py-12 text-center opacity-80">
           <svg class="mx-auto h-20 w-20 text-blue-300" fill="none" stroke="currentColor" stroke-width="2"
             viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round"


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción

- Se retira la lógica de formularios reactivos del componente principal de Device y se centraliza en el modal.
- Se implementan los métodos `startFormLoading` y `stopFormLoading` dentro del modal de crear/editar dispositivo, permitiendo visualizar el spinner en el botón mientras se ejecuta una acción (crear/editar).

## ¿Qué tipo de cambio es?
- [ ] Bugfix 🐞
- [x] Feature ✨
- [ ] Refactor 🔧
- [x] Documentación 📚
- [ ] Otro

## ¿Cómo probar estos cambios?

- Crear un dispositivo y verificar el correcto funcionamiento, incluyendo el feedback visual del spinner.
- Editar un dispositivo y validar que el spinner y resultado funcionen correctamente.
- Eliminar un dispositivo y confirmar que el flujo de la UI no se rompe.

## Checklist
- [x] El código compila y pasa los tests
- [x] La documentación está actualizada (si aplica)
- [x] No hay warnings nuevos
- [x] Revisé el formato y convenciones de código

## Screenshots (si aplica)
<!-- Adjunta capturas si hay cambios visuales. -->

## Issue relacionada
<!-- Si hay issues asociadas, referencia: closes #123 -->

## Notas para el revisor
<!-- Información extra útil para quien revisa el PR -->
