### PR TITLE
Merge main to dev

### DIFF
--- a/src/app/modules/private/dashboard/dashboard.component.html
+++ b/src/app/modules/private/dashboard/dashboard.component.html
@@ -6,525 +6,379 @@
   </div>
 </div>
 
-<!-- Alert de Error: Dispositivos -->
+<!-- Error de Dispositivos -->
 <div *ngIf="deviceError" class="alert alert-warning shadow-lg mb-4">
-  <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
-    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-  </svg>
-  <div class="flex-1">
-    <h3 class="font-bold">Error al cargar dispositivos</h3>
-    <div class="text-sm">{{ deviceErrorMessage }}</div>
-  </div>
-  <button
-    class="btn btn-sm btn-ghost gap-2"
-    (click)="retryDevices()"
-    [disabled]="isRetrying">
+  <!-- ...icono y mensaje... -->
+  <h3 class="font-bold">Error al cargar dispositivos</h3>
+  <div class="text-sm">{{ deviceErrorMessage }}</div>
+  <button class="btn btn-sm btn-ghost gap-2" (click)="retryDevices()" [disabled]="isRetrying">
     <span *ngIf="isRetrying" class="loading loading-spinner loading-xs"></span>
-    <svg *ngIf="!isRetrying" xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-    </svg>
     Reintentar
   </button>
 </div>
-
-<!-- Alert de Error: Órdenes -->
+<!-- Error de Órdenes -->
 <div *ngIf="orderError" class="alert alert-warning shadow-lg mb-4">
-  <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
-    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-  </svg>
-  <div class="flex-1">
-    <h3 class="font-bold">Error al cargar órdenes</h3>
-    <div class="text-sm">{{ orderErrorMessage }}</div>
-  </div>
-  <button
-    class="btn btn-sm btn-ghost gap-2"
-    (click)="retryOrders()"
-    [disabled]="isRetrying">
+  <!-- ...icono y mensaje... -->
+  <h3 class="font-bold">Error al cargar órdenes</h3>
+  <div class="text-sm">{{ orderErrorMessage }}</div>
+  <button class="btn btn-sm btn-ghost gap-2" (click)="retryOrders()" [disabled]="isRetrying">
     <span *ngIf="isRetrying" class="loading loading-spinner loading-xs"></span>
-    <svg *ngIf="!isRetrying" xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-    </svg>
     Reintentar
   </button>
 </div>
 
-<!-- Estado Vacío Global (solo si ambos fallan sin datos) -->
-<div *ngIf="deviceError && orderError && stats.totalDevices === 0 && stats.totalOrders === 0"
-     class="flex flex-col items-center justify-center py-16 px-4 text-center">
-  <svg xmlns="http://www.w3.org/2000/svg"
-       class="h-32 w-32 text-error opacity-20 mb-6"
-       fill="none"
-       viewBox="0 0 24 24"
-       stroke="currentColor">
-    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-          d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-  </svg>
+<ng-container *ngIf="dashboardStats$ | async as stats">
 
-  <h2 class="text-2xl font-bold mb-2 text-base-content">
-    No se pudieron cargar los datos
-  </h2>
-
-  <p class="text-base-content/60 mb-6 max-w-md">
-    Hubo un problema al conectar con el servidor.
-    Por favor verifica tu conexión e intenta nuevamente.
-  </p>
-
-  <button
-    class="btn btn-primary gap-2"
-    (click)="retryLoadData()"
-    [disabled]="isRetrying">
-    <span *ngIf="isRetrying" class="loading loading-spinner loading-sm"></span>
-    <svg *ngIf="!isRetrying" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-    </svg>
-    {{ isRetrying ? 'Reintentando...' : 'Volver a intentar' }}
-  </button>
-</div>
-
-<!-- Contenido Principal -->
-<!-- mostrar si no hay errores globales O hay datos previos -->
-<div *ngIf="!(deviceError && orderError) || stats.totalDevices > 0 || stats.totalOrders > 0"
-     class="transition-opacity duration-300"
-     [class.opacity-60]="loading$ | async"
-     [class.pointer-events-none]="loading$ | async">
-
-  <!-- Encabezado -->
-  <div class="mb-6">
-    <h1 class="text-3xl font-bold">{{ getGreeting() }}</h1>
-    <p class="text-base-content/60 mt-2">
-      Aquí está el resumen de tu sistema
+  <!-- Estado Vacío Global -->
+  <div *ngIf="deviceError && orderError && stats.totalDevices === 0 && stats.totalOrders === 0"
+    class="flex flex-col items-center justify-center py-16 px-4 text-center">
+    <h2 class="text-2xl font-bold mb-2 text-base-content">
+      No se pudieron cargar los datos
+    </h2>
+    <p class="text-base-content/60 mb-6 max-w-md">
+      Hubo un problema al conectar con el servidor.<br>
+      Por favor verifica tu conexión e intenta nuevamente.
     </p>
+    <button class="btn btn-primary gap-2" (click)="retryLoadData()" [disabled]="isRetrying">
+      <span *ngIf="isRetrying" class="loading loading-spinner loading-sm"></span>
+      {{ isRetrying ? 'Reintentando...' : 'Volver a intentar' }}
+    </button>
   </div>
 
-  <!-- Estado Vacío: Solo Dispositivos (cuando deviceError y no hay datos) -->
-  <div *ngIf="deviceError && stats.totalDevices === 0"
-       class="card bg-base-100 shadow-xl mb-6">
-    <div class="card-body text-center py-12">
-      <svg xmlns="http://www.w3.org/2000/svg"
-           class="h-16 w-16 mx-auto text-warning opacity-30 mb-4"
-           fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-              d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
-      </svg>
-      <h3 class="text-xl font-semibold mb-2">No se pudieron cargar los dispositivos</h3>
-      <p class="text-base-content/60 mb-4">{{ deviceErrorMessage }}</p>
-      <button class="btn btn-primary btn-sm gap-2" (click)="retryDevices()" [disabled]="isRetrying">
-        <span *ngIf="isRetrying" class="loading loading-spinner loading-xs"></span>
-        {{ isRetrying ? 'Reintentando...' : 'Reintentar' }}
-      </button>
-    </div>
-  </div>
+  <!-- DASHBOARD PRINCIPAL -->
+  <div *ngIf="!(deviceError && orderError && stats.totalDevices === 0 && stats.totalOrders === 0)"
+    class="transition-opacity duration-300" [class.opacity-60]="loading$ | async"
+    [class.pointer-events-none]="loading$ | async">
 
-  <!-- Stats Cards: Dispositivos (mostrar si NO hay error O hay datos previos) -->
-  <div *ngIf="stats.totalDevices > 0"
-       class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-
-    <!-- Total Dispositivos -->
-    <div class="stats shadow-lg hover:shadow-xl transition-shadow">
-      <div class="stat">
-        <div class="stat-figure text-primary">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-              d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
-          </svg>
-        </div>
-        <div class="stat-title">Total Dispositivos</div>
-        <div class="stat-value text-primary">{{ stats.totalDevices }}</div>
-        <div class="stat-desc">
-          {{ stats.goodCondition }} en buen estado
-        </div>
-      </div>
+    <!-- HEADER -->
+    <div class="mb-6">
+      <h1 class="text-3xl font-bold">{{ getGreeting() }}</h1>
+      <p class="text-base-content/60 mt-2">Aquí está el resumen de tu sistema</p>
     </div>
 
-    <!-- Necesitan Reparación -->
-    <div class="stats shadow-lg hover:shadow-xl transition-shadow">
-      <div class="stat">
-        <div class="stat-figure text-error">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-          </svg>
-        </div>
-        <div class="stat-title">Necesitan Reparación</div>
-        <div class="stat-value text-error">{{ stats.needsRepair }}</div>
-        <div class="stat-desc">
-          {{ getPercentage(stats.needsRepair, stats.totalDevices) }}% del total
-        </div>
-      </div>
-    </div>
-
-    <!-- Ocupados -->
-    <div class="stats shadow-lg hover:shadow-xl transition-shadow">
-      <div class="stat">
-        <div class="stat-figure text-info">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-              d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-          </svg>
-        </div>
-        <div class="stat-title">Ocupados</div>
-        <div class="stat-value text-info">{{ stats.occupied }}</div>
-        <div class="stat-desc">
-          {{ getPercentage(stats.occupied, stats.totalDevices) }}% en uso
-        </div>
-      </div>
-    </div>
-
-    <!-- Estado Regular -->
-    <div class="stats shadow-lg hover:shadow-xl transition-shadow">
-      <div class="stat">
-        <div class="stat-figure text-warning">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
-          </svg>
-        </div>
-        <div class="stat-title">Estado Regular</div>
-        <div class="stat-value text-warning">{{ stats.fair }}</div>
-        <div class="stat-desc">
-          {{ getPercentage(stats.fair, stats.totalDevices) }}% del total
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Dispositivos por Marca -->
-  <div *ngIf="devicesByBrand.length > 0" class="card bg-base-100 shadow-xl mt-6">
-    <div class="card-body">
-      <h2 class="card-title">📊 Top 5 Marcas</h2>
-      <div class="space-y-4">
-        <div *ngFor="let item of devicesByBrand" class="flex items-center gap-4">
-          <div class="font-semibold w-24 text-sm">{{ item.brand }}</div>
-          <div class="flex-1">
-            <div class="flex items-center gap-2">
-              <progress class="progress progress-primary w-full" [value]="item.count" [max]="stats.totalDevices">
-              </progress>
-              <span class="text-xs text-base-content/60">
-                {{ getPercentage(item.count, stats.totalDevices) }}%
-              </span>
+    <!-- CARDS de DISPOSITIVOS (alertas/avisos de dispositivos) -->
+    <ng-container *ngIf="getAlerts(stats) as alerts">
+      <div *ngIf="alerts.length > 0" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
+        <div *ngFor="let alert of alerts" class="alert shadow-lg" [ngClass]="getAlertClass(alert.type)">
+          <div>
+            <span class="text-2xl">{{ alert.icon }}</span>
+            <div>
+              <h3 class="font-bold">{{ alert.title }}</h3>
+              <div class="text-xs">{{ alert.message }}</div>
             </div>
           </div>
-          <div class="badge badge-lg badge-neutral">{{ item.count }}</div>
+          <div class="flex-none">
+            <div class="badge badge-lg">{{ alert.count }}</div>
+          </div>
+        </div>
+      </div>
+    </ng-container>
+
+    <!-- STATS: DISPOSITIVOS -->
+    <div *ngIf="stats.totalDevices > 0">
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
+        <!-- Total Dispositivos -->
+        <div class="stats shadow-xl">
+          <div class="stat">
+            <div class="stat-figure text-primary">
+              <!-- Dispositivo (Tablet/Dispositivo Genérico) -->
+              <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
+              </svg>
+            </div>
+            <div class="stat-title">Total Dispositivos</div>
+            <div class="stat-value text-primary">{{ stats.totalDevices }}</div>
+            <div class="stat-desc">{{ stats.goodCondition }} en buen estado</div>
+          </div>
+        </div>
+
+        <!-- Estado Regular -->
+        <div class="stats shadow-xl">
+          <div class="stat">
+            <div class="stat-figure text-warning">
+              <!-- Exclamation Alert (Estado Regular/Advertencia) -->
+              <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M13 16h-1v-4h-1m0-4h.01M12 2a10 10 0 100 20 10 10 0 000-20z" />
+              </svg>
+            </div>
+            <div class="stat-title">Estado Regular</div>
+            <div class="stat-value text-warning">{{ stats.fair }}</div>
+            <div class="stat-desc">{{ getPercentage(stats.fair, stats.totalDevices) }}% del total</div>
+          </div>
+        </div>
+
+        <!-- Ocupados -->
+        <div class="stats shadow-xl">
+          <div class="stat">
+            <div class="stat-figure text-info">
+              <!-- User Group (Ocupados) -->
+              <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M17 20h5v-2a4 4 0 00-3-3.87M9 20H4v-2a4 4 0 013-3.87M16 7a4 4 0 11-8 0 4 4 0 018 0zm6 13a6 6 0 00-12 0v1h12v-1z" />
+              </svg>
+            </div>
+            <div class="stat-title">Ocupados</div>
+            <div class="stat-value text-info">{{ stats.occupied }}</div>
+            <div class="stat-desc">{{ getPercentage(stats.occupied, stats.totalDevices) }}% en uso</div>
+          </div>
+        </div>
+
+        <!-- Necesitan Reparación -->
+        <div class="stats shadow-xl">
+          <div class="stat">
+            <div class="stat-figure text-error">
+              <!-- Herramienta/Llave inglesa (Reparación) -->
+              <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M15.232 5.232l2.536-2.536a2 2 0 112.828 2.828l-2.536 2.536M9 13l3 3m0 0l6 6m-6-6l-6 6m6-6l-3-3" />
+              </svg>
+            </div>
+            <div class="stat-title">Necesitan Reparación</div>
+            <div class="stat-value text-error">{{ stats.needsRepair }}</div>
+            <div class="stat-desc">{{ getPercentage(stats.needsRepair, stats.totalDevices) }}% del total</div>
+          </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <!-- Estado Vacío: Solo Órdenes (cuando orderError y no hay datos) -->
-  <div *ngIf="orderError && stats.totalOrders === 0"
-       class="card bg-base-100 shadow-xl mt-6 mb-6">
-    <div class="card-body text-center py-12">
-      <svg xmlns="http://www.w3.org/2000/svg"
-           class="h-16 w-16 mx-auto text-warning opacity-30 mb-4"
-           fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-              d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-      </svg>
-      <h3 class="text-xl font-semibold mb-2">No se pudieron cargar las órdenes</h3>
-      <p class="text-base-content/60 mb-4">{{ orderErrorMessage }}</p>
-      <button class="btn btn-primary btn-sm gap-2" (click)="retryOrders()" [disabled]="isRetrying">
-        <span *ngIf="isRetrying" class="loading loading-spinner loading-xs"></span>
-        {{ isRetrying ? 'Reintentando...' : 'Reintentar' }}
-      </button>
-    </div>
-  </div>
-
-  <!-- Stats Cards: Órdenes -->
-  <div *ngIf="stats.totalOrders > 0"
-    class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mt-6" >
-    <!-- Total Órdenes -->
-    <div class="stats shadow-lg hover:shadow-xl transition-shadow">
-      <div class="stat">
-        <div class="stat-figure text-secondary">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-              d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-          </svg>
-        </div>
-        <div class="stat-title">Total Órdenes</div>
-        <div class="stat-value text-secondary">{{ stats.totalOrders }}</div>
-        <div class="stat-desc">
-          {{ stats.activeOrders }} activas
+    <!-- Dispositivos por Marca -->
+    <div *ngIf="devicesByBrand.length > 0" class="card bg-base-100 shadow-xl mb-6">
+      <div class="card-body">
+        <h2 class="card-title">📊 Top 5 Marcas</h2>
+        <div class="space-y-2">
+          <div *ngFor="let item of devicesByBrand" class="flex items-center gap-4">
+            <div class="w-24 font-semibold">{{ item.brand }}</div>
+            <div class="flex-1">
+              <progress class="progress progress-primary w-full" [value]="item.count"
+                [max]="stats.totalDevices"></progress>
+            </div>
+            <div class="badge badge-lg badge-neutral">{{ item.count }}</div>
+          </div>
         </div>
       </div>
     </div>
 
-    <!-- Órdenes Creadas -->
-    <div class="stats shadow-lg hover:shadow-xl transition-shadow">
-      <div class="stat">
-        <div class="stat-figure text-info">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-          </svg>
-        </div>
-        <div class="stat-title">Creadas</div>
-        <div class="stat-value text-info">{{ stats.createdOrders }}</div>
-        <div class="stat-desc">
-          {{ getPercentage(stats.createdOrders, stats.totalOrders) }}% del total
-        </div>
-      </div>
-    </div>
-
-    <!-- Órdenes en Progreso -->
-    <div class="stats shadow-lg hover:shadow-xl transition-shadow">
-      <div class="stat">
-        <div class="stat-figure text-warning">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
-          </svg>
-        </div>
-        <div class="stat-title">En Progreso</div>
-        <div class="stat-value text-warning">{{ stats.inProgressOrders }}</div>
-        <div class="stat-desc">
-          + {{ stats.despatchedOrders }} despachadas
-        </div>
-      </div>
-    </div>
-
-    <!-- Órdenes Finalizadas -->
-    <div class="stats shadow-lg hover:shadow-xl transition-shadow">
-      <div class="stat">
-        <div class="stat-figure text-success">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-              d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-          </svg>
-        </div>
-        <div class="stat-title">Finalizadas</div>
-        <div class="stat-value text-success">{{ stats.finishedOrders }}</div>
-        <div class="stat-desc">
-          {{ getPercentage(stats.finishedOrders, stats.totalOrders) }}% completadas
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Alertas -->
-  <div *ngIf="alerts.length > 0" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mt-6">
-    <div *ngFor="let alert of alerts" class="alert shadow-lg" [ngClass]="getAlertClass(alert.type)">
-      <div>
-        <span class="text-2xl">{{ alert.icon }}</span>
-        <div>
-          <h3 class="font-bold">{{ alert.title }}</h3>
-          <div class="text-xs">{{ alert.message }}</div>
-        </div>
-      </div>
-      <div class="flex-none">
-        <div class="badge badge-lg">{{ alert.count }}</div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Órdenes Recientes -->
-  <div *ngIf="recentOrders.length > 0" class="card bg-base-100 shadow-xl mt-6">
-    <div class="card-body">
-      <div class="flex justify-between items-center mb-4">
-        <h2 class="card-title">📋 Órdenes Recientes</h2>
-        <button class="btn btn-sm btn-ghost gap-2"
-        (click)="refreshData()"
-        [disabled]="loading$ | async">
-        <span *ngIf="loading$ | async" class="loading loading-spinner loading-xs"></span>
-          <svg *ngIf="!(loading$ | async)" xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-          </svg>
-         <span class="hidden sm:inline">
-            {{ (loading$ | async) ? 'Actualizando...' : 'Actualizar' }}
-          </span>
+    <!-- Estado Vacío solo Devices -->
+    <div *ngIf="deviceError && stats.totalDevices === 0" class="card bg-base-100 shadow-xl mb-6">
+      <div class="card-body text-center py-12">
+        <h3 class="text-xl font-semibold mb-2">No se pudieron cargar los dispositivos</h3>
+        <p class="text-base-content/60 mb-4">{{ deviceErrorMessage }}</p>
+        <button class="btn btn-primary btn-sm gap-2" (click)="retryDevices()" [disabled]="isRetrying">
+          <span *ngIf="isRetrying" class="loading loading-spinner loading-xs"></span>
+          {{ isRetrying ? 'Reintentando...' : 'Reintentar' }}
         </button>
       </div>
-
-      <div class="overflow-x-auto">
-        <table class="table table-zebra">
-          <thead>
-            <tr>
-              <th>ID</th>
-              <th>Descripción</th>
-              <th>Dispositivos</th>
-              <th>Asignado</th>
-              <th>Estado</th>
-              <th>Fecha</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr *ngFor="let order of recentOrders" class="hover">
-              <!-- ID corto con tooltip -->
-              <td>
-                <div class="tooltip" [attr.data-tip]="order.id">
-                  <code class="text-xs">{{ getShortId(order.id) }}</code>
-                </div>
-              </td>
-
-              <!-- Descripción -->
-              <td>
-                <div class="max-w-xs" [title]="order.description">
-                  {{ getTruncatedDescription(order.description, 40) }}
-                </div>
-              </td>
-
-              <!-- Dispositivos -->
-              <td>
-                <div class="badge badge-neutral badge-lg">
-                  {{ getDeviceCount(order) }}
-                </div>
-                <!-- Estados de dispositivos -->
-                <div class="flex gap-1 mt-1">
-                  <span *ngFor="let item of order.items.slice(0, 3)" class="badge badge-xs"
-                    [ngClass]="getDeviceStateColor(item.originalDeviceState)">
-                    {{ item.originalDeviceState.substring(0, 4) }}
-                  </span>
-                  <span *ngIf="order.items.length > 3" class="badge badge-xs">
-                    +{{ order.items.length - 3 }}
-                  </span>
-                </div>
-              </td>
-
-              <!-- Asignado -->
-              <td>
-                <div class="flex items-center gap-2">
-                  <span class="text-lg">{{ getAssigneeIcon(order.assigneeType) }}</span>
-                  <div class="text-sm">
-                    <div class="font-semibold">{{ order.assigneeType }}</div>
-                    <div class="tooltip" [attr.data-tip]="order.assigneeId">
-                      <code class="text-xs opacity-60">{{ getShortId(order.assigneeId) }}</code>
-                    </div>
-                  </div>
-                </div>
-              </td>
-
-              <!-- Estado -->
-              <td>
-                <span class="badge badge-lg" [ngClass]="getOrderStateClass(order.state)">
-                  {{ getOrderStateText(order.state) }}
-                </span>
-              </td>
-
-              <!-- Fecha -->
-              <td>
-                <div class="text-sm">
-                  <div class="font-medium">{{ formatDate(order.createdAt) }}</div>
-                  <div class="text-xs opacity-60">{{ getRelativeTime(order.createdAt) }}</div>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <!-- Mensaje si no hay órdenes -->
-      <div *ngIf="recentOrders.length === 0" class="text-center py-8 text-base-content/60">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mx-auto mb-4 opacity-50" fill="none"
-          viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-            d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-        </svg>
-        <p class="text-lg font-semibold">No hay órdenes recientes</p>
-        <p class="text-sm">Las nuevas órdenes aparecerán aquí</p>
-      </div>
     </div>
-  </div>
 
-  <!-- Estado de Órdenes (Gráfico de Barras) -->
-  <div *ngIf="stats.totalOrders > 0" class="card bg-base-100 shadow-xl mt-6">
-    <div class="card-body">
-      <h2 class="card-title">📊 Estado de Órdenes</h2>
-      <div class="space-y-4">
-        <!-- Creadas -->
-        <div class="flex items-center gap-4">
-          <div class="font-semibold w-32 text-sm">
-            <span class="badge badge-info">{{ orderStates.CREATED }}</span>
-          </div>
-          <div class="flex-1">
-            <div class="flex items-center gap-2">
-              <progress class="progress progress-info w-full" [value]="stats.createdOrders" [max]="stats.totalOrders">
-              </progress>
-              <span class="text-xs text-base-content/60">
-                {{ getPercentage(stats.createdOrders, stats.totalOrders) }}%
-              </span>
+    <!-- STATS: ÓRDENES -->
+    <div *ngIf="stats.totalOrders > 0">
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6 mt-2">
+        <!-- Total Órdenes -->
+        <div class="stats shadow-xl">
+          <div class="stat">
+            <div class="stat-figure text-secondary">
+              <!-- Clipboard (órdenes, abstracto general) -->
+              <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M9 5h6a2 2 0 012 2v12a2 2 0 01-2 2H9a2 2 0 01-2-2V7a2 2 0 012-2z" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 3h6v2H9V3z" />
+              </svg>
             </div>
+            <div class="stat-title">Total Órdenes</div>
+            <div class="stat-value text-secondary">{{ stats.totalOrders }}</div>
+            <div class="stat-desc">{{ stats.activeOrders }} activas</div>
           </div>
-          <div class="badge badge-lg badge-neutral">{{ stats.createdOrders }}</div>
+        </div>
+
+        <!-- Órdenes Creadas -->
+        <div class="stats shadow-xl">
+          <div class="stat">
+            <div class="stat-figure text-info">
+              <!-- Plus Circle (nuevas/creadas) -->
+              <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M12 9v6m3-3H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </div>
+            <div class="stat-title">Creadas</div>
+            <div class="stat-value text-info">{{ stats.createdOrders }}</div>
+            <div class="stat-desc">{{ getPercentage(stats.createdOrders, stats.totalOrders) }}% del total</div>
+          </div>
         </div>
 
         <!-- En Progreso -->
-        <div class="flex items-center gap-4">
-          <div class="font-semibold w-32 text-sm">
-            <span class="badge badge-warning">{{ orderStates.IN_PROGRESS }}</span>
-          </div>
-          <div class="flex-1">
-            <div class="flex items-center gap-2">
-              <progress class="progress progress-warning w-full" [value]="stats.inProgressOrders"
-                [max]="stats.totalOrders">
-              </progress>
-              <span class="text-xs text-base-content/60">
-                {{ getPercentage(stats.inProgressOrders, stats.totalOrders) }}%
-              </span>
+        <div class="stats shadow-xl">
+          <div class="stat">
+            <div class="stat-figure text-warning">
+              <!-- Cog (en progreso) -->
+              <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M11 17a1 1 0 002 0m-8-6a1 1 0 010-2m16 2a1 1 0 010-2m-1.832-7.445A1 1 0 0016 5a1 1 0 00-1-1 1.001 1.001 0 01-.445-1.832M6.832 2.445A1 1 0 008 3a1 1 0 001 1 1.001 1.001 0 01.445 1.832M3 16.168A1 1 0 014 17a1 1 0 001 1 1.001 1.001 0 011.832.445M21 16.168A1 1 0 0020 17a1 1 0 00-1 1 1.001 1.001 0 00-.445 1.832" />
+                <circle cx="12" cy="12" r="3" />
+              </svg>
             </div>
+            <div class="stat-title">En Progreso</div>
+            <div class="stat-value text-warning">{{ stats.inProgressOrders }}</div>
+            <div class="stat-desc">+ {{ stats.despatchedOrders }} despachadas</div>
           </div>
-          <div class="badge badge-lg badge-neutral">{{ stats.inProgressOrders }}</div>
-        </div>
-
-        <!-- Despachadas -->
-        <div class="flex items-center gap-4">
-          <div class="font-semibold w-32 text-sm">
-            <span class="badge badge-primary">{{ orderStates.DISPATCHED }}</span>
-          </div>
-          <div class="flex-1">
-            <div class="flex items-center gap-2">
-              <progress class="progress progress-primary w-full" [value]="stats.despatchedOrders"
-                [max]="stats.totalOrders">
-              </progress>
-              <span class="text-xs text-base-content/60">
-                {{ getPercentage(stats.despatchedOrders, stats.totalOrders) }}%
-              </span>
-            </div>
-          </div>
-          <div class="badge badge-lg badge-neutral">{{ stats.despatchedOrders }}</div>
         </div>
 
         <!-- Finalizadas -->
-        <div class="flex items-center gap-4">
-          <div class="font-semibold w-32 text-sm">
-            <span class="badge badge-success">{{ orderStates.FINISHED }}</span>
-          </div>
-          <div class="flex-1">
-            <div class="flex items-center gap-2">
-              <progress class="progress progress-success w-full" [value]="stats.finishedOrders"
-                [max]="stats.totalOrders">
-              </progress>
-              <span class="text-xs text-base-content/60">
-                {{ getPercentage(stats.finishedOrders, stats.totalOrders) }}%
-              </span>
+        <div class="stats shadow-xl">
+          <div class="stat">
+            <div class="stat-figure text-success">
+              <!-- Check Circle (finalizadas) -->
+              <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
             </div>
+            <div class="stat-title">Finalizadas</div>
+            <div class="stat-value text-success">{{ stats.finishedOrders }}</div>
+            <div class="stat-desc">{{ getPercentage(stats.finishedOrders, stats.totalOrders) }}% completadas</div>
           </div>
-          <div class="badge badge-lg badge-neutral">{{ stats.finishedOrders }}</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Estado Vacío solo Órdenes -->
+    <div *ngIf="orderError && stats.totalOrders === 0" class="card bg-base-100 shadow-xl mt-6 mb-6">
+      <div class="card-body text-center py-12">
+        <h3 class="text-xl font-semibold mb-2">No se pudieron cargar las órdenes</h3>
+        <p class="text-base-content/60 mb-4">{{ orderErrorMessage }}</p>
+        <button class="btn btn-primary btn-sm gap-2" (click)="retryOrders()" [disabled]="isRetrying">
+          <span *ngIf="isRetrying" class="loading loading-spinner loading-xs"></span>
+          {{ isRetrying ? 'Reintentando...' : 'Reintentar' }}
+        </button>
+      </div>
+    </div>
+
+    <!-- ÓRDENES RECIENTES: Detalle de la tabla -->
+    <div *ngIf="recentOrders.length > 0" class="card bg-base-100 shadow-xl mt-6">
+      <div class="card-body">
+        <div class="flex justify-between items-center mb-4">
+          <h2 class="card-title">📋 Órdenes Recientes</h2>
+          <button class="btn btn-sm btn-ghost gap-2" (click)="refreshData()" [disabled]="loading$ | async">
+            <span *ngIf="loading$ | async" class="loading loading-spinner loading-xs"></span>
+            <span class="hidden sm:inline">
+              {{ (loading$ | async) ? 'Actualizando...' : 'Actualizar' }}
+            </span>
+          </button>
+        </div>
+        <div class="overflow-x-auto">
+          <table class="table table-zebra">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Descripción</th>
+                <th>Dispositivos</th>
+                <th>Asignado</th>
+                <th>Estado</th>
+                <th>Fecha</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let order of recentOrders" class="hover">
+                <td>
+                  <div class="tooltip" [attr.data-tip]="order.id">
+                    <code class="text-xs">{{ getShortId(order.id) }}</code>
+                  </div>
+                </td>
+                <td>
+                  <div class="max-w-xs" [title]="order.description">
+                    {{ getTruncatedDescription(order.description, 40) }}
+                  </div>
+                </td>
+                <td>
+                  <div class="badge badge-neutral badge-lg">
+                    {{ getDeviceCount(order) }}
+                  </div>
+                </td>
+                <td>
+                  <div class="flex items-center gap-2">
+                    <span class="text-lg">{{ getAssigneeIcon(order.assigneeType) }}</span>
+                    <div class="text-sm">
+                      <div class="font-semibold">{{ order.assigneeType }}</div>
+                      <div class="tooltip" [attr.data-tip]="order.assigneeId">
+                        <code class="text-xs opacity-60">{{ getShortId(order.assigneeId) }}</code>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <span class="badge badge-lg" [ngClass]="getOrderStateClass(order.state)">
+                    {{ getOrderStateText(order.state) }}
+                  </span>
+                </td>
+                <td>
+                  <div class="text-sm">
+                    <div class="font-medium">{{ formatDate(order.createdAt) }}</div>
+                    <div class="text-xs opacity-60">{{ getRelativeTime(order.createdAt) }}</div>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div *ngIf="recentOrders.length === 0" class="text-center py-8 text-base-content/60">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mx-auto mb-4 opacity-50" fill="none"
+            viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+          </svg>
+          <p class="text-lg font-semibold">No hay órdenes recientes</p>
+          <p class="text-sm">Las nuevas órdenes aparecerán aquí</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Estadística Adicional de Órdenes: Dispositivos en Órdenes (AL FINAL) -->
+    <div *ngIf="stats.totalOrders > 0" class="card bg-base-100 shadow-xl mt-6">
+      <div class="card-body">
+        <h2 class="card-title">📱 Dispositivos en Órdenes</h2>
+        <div class="stats stats-vertical lg:stats-horizontal shadow">
+
+          <div class="stat">
+            <div class="stat-figure text-primary">
+              <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M20 13V7a2 2 0 00-2-2H6a2 2 0 00-2 2v6m16 0V7a2 2 0 00-2-2m0 8v6a2 2 0 01-2 2H8a2 2 0 01-2-2v-6m16 0l-8 5-8-5" />
+              </svg>
+            </div>
+            <div class="stat-title">Total Dispositivos</div>
+            <div class="stat-value text-primary">{{ stats.totalDevicesInOrders }}</div>
+            <div class="stat-desc">En {{ stats.totalOrders }} órdenes</div>
+          </div>
+
+          <div class="stat">
+            <div class="stat-figure text-secondary">
+              <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M16 17a4 4 0 01-8 0M12 3v14m7 4H5m4-4H7a2 2 0 01-2-2v-5a2 2 0 012-2h2a2 2 0 012 2v5a2 2 0 01-2 2zm6 0h2a2 2 0 002-2v-5a2 2 0 00-2-2h-2a2 2 0 00-2 2v5a2 2 0 002 2z" />
+              </svg>
+            </div>
+            <div class="stat-title">Promedio por Orden</div>
+            <div class="stat-value text-secondary">{{ stats.averageItemsPerOrder }}</div>
+            <div class="stat-desc">Dispositivos por orden</div>
+          </div>
+
+          <div class="stat">
+            <div class="stat-figure text-accent">
+              <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M9 12l2 2l4-4m4 2A9 9 0 11 3 12a9 9 0 0118 0z" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h6" />
+              </svg>
+            </div>
+            <div class="stat-title">Órdenes Activas</div>
+            <div class="stat-value text-accent">{{ stats.activeOrders }}</div>
+            <div class="stat-desc">{{ getPercentage(stats.activeOrders, stats.totalOrders) }}% del total</div>
+          </div>
+
         </div>
       </div>
     </div>
   </div>
-
-  <!-- Estadística Adicional: Dispositivos en Órdenes -->
-  <div *ngIf="stats.totalOrders > 0" class="card bg-base-100 shadow-xl mt-6">
-    <div class="card-body">
-      <h2 class="card-title">📱 Dispositivos en Órdenes</h2>
-      <div class="stats stats-vertical lg:stats-horizontal shadow">
-        <div class="stat">
-          <div class="stat-title">Total Dispositivos</div>
-          <div class="stat-value text-primary">{{ stats.totalDevicesInOrders }}</div>
-          <div class="stat-desc">En {{ stats.totalOrders }} órdenes</div>
-        </div>
-
-        <div class="stat">
-          <div class="stat-title">Promedio por Orden</div>
-          <div class="stat-value text-secondary">{{ stats.averageItemsPerOrder }}</div>
-          <div class="stat-desc">Dispositivos por orden</div>
-        </div>
-
-        <div class="stat">
-          <div class="stat-title">Órdenes Activas</div>
-          <div class="stat-value text-accent">{{ stats.activeOrders }}</div>
-          <div class="stat-desc">{{ getPercentage(stats.activeOrders, stats.totalOrders) }}% del total</div>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+</ng-container>

--- a/src/app/modules/private/dashboard/dashboard.component.ts
+++ b/src/app/modules/private/dashboard/dashboard.component.ts
@@ -5,12 +5,13 @@ import { DevicesService } from '../devices/services/devices.service';
 import { AuthService } from '../../../core/services/auth.service';
 import { User } from '../../public/auth/models/user.model';
 import { forkJoin } from 'rxjs/internal/observable/forkJoin';
-import { catchError, Observable, of } from 'rxjs';
+import { catchError, Observable, of, map } from 'rxjs';
 import { Device, DeviceStatus } from '../devices/models/device.model';
 import { takeUntil } from 'rxjs/internal/operators/takeUntil';
 import { Subject } from 'rxjs/internal/Subject';
 import { OrdersService } from '../orders/services/orders.service';
 import { LoadingService } from '../../../core/services/loading.service';
+import { Alerta, DashboardStatsType } from './models/DashboardStats';
 
 /**
  * Componente de Dashboard
@@ -34,43 +35,44 @@ export class DashboardComponent implements OnInit, OnDestroy {
     return this.loadingService.loading$;
   }
 
-  // Estado de carga
-  stats = {
-    // Dispositivos
+  // Observables para estadísticas y datos del dashboard
+  dashboardStats$: Observable<{
+    totalDevices: number;
+    goodCondition: number;
+    occupied: number;
+    needsRepair: number;
+    fair: number;
+    totalOrders: number;
+    activeOrders: number;
+    createdOrders: number;
+    inProgressOrders: number;
+    despatchedOrders: number;
+    finishedOrders: number;
+    totalDevicesInOrders: number;
+    averageItemsPerOrder: number;
+  }> = of({
     totalDevices: 0,
     goodCondition: 0,
     occupied: 0,
     needsRepair: 0,
     fair: 0,
-
-    // Ordenes
     totalOrders: 0,
     activeOrders: 0,
     createdOrders: 0,
     inProgressOrders: 0,
     despatchedOrders: 0,
     finishedOrders: 0,
-
-    // Otros
     totalDevicesInOrders: 0,
     averageItemsPerOrder: 0,
-  };
+  });
 
+  // Datos para mostrar en el dashboard
   recentDevices: Device[] = [];
   recentOrders: Order[] = [];
   devicesByBrand: { brand: string; count: number }[] = [];
 
   // Referencia a orderStates para usar en el template
   orderStates = OrderStates;
-
-  // Alertas dinámicas
-  alerts: Array<{
-    type: string;
-    icon: string;
-    title: string;
-    message: string;
-    count: number;
-  }> = [];
 
   // Manejo de errores
   deviceError = false;
@@ -84,10 +86,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
     return this.deviceError || this.orderError;
   }
 
+  // Subject para manejar desuscripciones y evitar fugas de memoria
   destroy$: Subject<void> = new Subject<void>();
-
-  // Bandera para evitar recargas múltiples al inicializar el componente
-  private hasLoadedOnce = false;
 
   constructor(
     private devicesService: DevicesService,
@@ -123,7 +123,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.loadDashboardData();
   }
 
-
   /**
    * Carga los datos del dashboard, incluyendo dispositivos y órdenes,
    * y maneja los errores de forma individual para cada recurso, permitiendo mostrar
@@ -135,53 +134,84 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.deviceErrorMessage = '';
     this.orderError = false;
     this.orderErrorMessage = '';
-    forkJoin({
+    this.dashboardStats$ = forkJoin({
       devices: this.devicesService.getAllDevices().pipe(
         catchError((error) => {
-          console.error(' Error al cargar dispositivos:', error);
+          console.error('Error al cargar dispositivos:', error);
           this.deviceError = true;
           this.deviceErrorMessage =
             error.message || 'Error al cargar dispositivos';
-          return of([]);
+          return of([] as Device[]);
         }),
       ),
       orders: this.ordersService.getAllOrders().pipe(
         catchError((error) => {
-          console.error(' Error al cargar órdenes:', error);
+          console.error('Error al cargar órdenes:', error);
           this.orderError = true;
           this.orderErrorMessage = error.message || 'Error al cargar órdenes';
-          return of([]);
+          return of([] as Order[]);
         }),
       ),
-    })
-      .pipe(takeUntil(this.destroy$))
-      .subscribe({
-        next: ({ devices, orders }) => {
-          // Procesar dispositivos (puede ser [])
-          if (devices.length > 0) {
-            this.calculateDeviceStats(devices);
-            this.recentDevices = this.getRecentDevices(devices, 5);
-            this.devicesByBrand = this.getDevicesByBrand(devices);
-          } else if (!this.deviceError) {
-            this.resetDeviceStats();
-          }
+    }).pipe(
+      map(({ devices, orders }) => {
+        this.recentOrders = this.getRecentOrders(orders, 5);
+        this.devicesByBrand = this.getDevicesByBrand(devices);
+        const totalDevices = devices.length;
+        const goodCondition = devices.filter(
+          (d) => d.status === DeviceStatus.GOOD_CONDITION,
+        ).length;
+        const occupied = devices.filter(
+          (d) => d.status === DeviceStatus.OCCUPIED,
+        ).length;
+        const needsRepair = devices.filter(
+          (d) => d.status === DeviceStatus.NEEDS_REPAIR,
+        ).length;
+        const fair = devices.filter(
+          (d) => d.status === DeviceStatus.FAIR,
+        ).length;
 
-          // Procesar órdenes (puede ser [])
-          if (orders.length > 0) {
-            this.calculateOrderStats(orders);
-            this.recentOrders = this.getRecentOrders(orders, 5);
-            this.updateAlerts();
-          } else if (!this.orderError) {
-            this.resetOrderStats();
-          }
+        const totalOrders = orders.length;
+        const createdOrders = orders.filter(
+          (o) => o.state === 'CREATED',
+        ).length;
+        const inProgressOrders = orders.filter(
+          (o) => o.state === 'IN_PROGRESS',
+        ).length;
+        const despatchedOrders = orders.filter(
+          (o) => o.state === 'DISPATCHED',
+        ).length;
+        const finishedOrders = orders.filter(
+          (o) => o.state === 'FINISHED',
+        ).length;
+        const activeOrders =
+          createdOrders + inProgressOrders + despatchedOrders;
 
-          this.hasLoadedOnce = true;
-          this.isRetrying = false;
-        },
-        error: (error) => {
-          console.error(' Error inesperado:', error);
-        },
-      });
+        const totalDevicesInOrders = orders.reduce(
+          (sum, order) => sum + (order.items?.length || 0),
+          0,
+        );
+        const averageItemsPerOrder =
+          orders.length > 0
+            ? Math.round((totalDevicesInOrders / orders.length) * 10) / 10
+            : 0;
+
+        return {
+          totalDevices,
+          goodCondition,
+          occupied,
+          needsRepair,
+          fair,
+          totalOrders,
+          activeOrders,
+          createdOrders,
+          inProgressOrders,
+          despatchedOrders,
+          finishedOrders,
+          totalDevicesInOrders,
+          averageItemsPerOrder,
+        };
+      }),
+    );
   }
 
   /**
@@ -250,13 +280,11 @@ export class DashboardComponent implements OnInit, OnDestroy {
       )
       .subscribe((devices) => {
         if (devices.length > 0) {
-          this.calculateDeviceStats(devices);
           this.recentDevices = this.getRecentDevices(devices, 5);
           this.devicesByBrand = this.getDevicesByBrand(devices);
         } else {
           // Si no hay datos y no hay error, resetear
           if (!this.deviceError) {
-            this.resetDeviceStats();
             this.recentDevices = [];
             this.devicesByBrand = [];
           }
@@ -289,45 +317,14 @@ export class DashboardComponent implements OnInit, OnDestroy {
       )
       .subscribe((orders) => {
         if (orders.length > 0) {
-          this.calculateOrderStats(orders);
           this.recentOrders = this.getRecentOrders(orders, 5);
-          this.updateAlerts();
         } else {
           if (!this.orderError) {
-            this.resetOrderStats();
             this.recentOrders = [];
-            this.alerts = [];
           }
         }
         this.isRetrying = false;
       });
-  }
-
-  /**
-   * Resetear solo estadísticas de dispositivos
-   * @returns void
-   */
-  private resetDeviceStats(): void {
-    this.stats.totalDevices = 0;
-    this.stats.goodCondition = 0;
-    this.stats.occupied = 0;
-    this.stats.needsRepair = 0;
-    this.stats.fair = 0;
-  }
-
-  /**
-   * Resetear solo estadísticas de órdenes
-   * @returns void
-   */
-  private resetOrderStats(): void {
-    this.stats.totalOrders = 0;
-    this.stats.activeOrders = 0;
-    this.stats.createdOrders = 0;
-    this.stats.inProgressOrders = 0;
-    this.stats.despatchedOrders = 0;
-    this.stats.finishedOrders = 0;
-    this.stats.totalDevicesInOrders = 0;
-    this.stats.averageItemsPerOrder = 0;
   }
 
   /**
@@ -370,7 +367,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
    */
   private loadUser(): void {
     this.user = this.authService.getCurrentUser();
-    // console.log('👤 Usuario en Dashboard:', this.user);
   }
 
   /**
@@ -413,65 +409,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Calcular estadísticas de dispositivos en base a su estado
-   * @param devices Lista de dispositivos
-   * @return void
-   */
-  private calculateDeviceStats(devices: Device[]): void {
-    this.stats.totalDevices = devices.length;
-    this.stats.goodCondition = devices.filter(
-      (d) => d.status === DeviceStatus.GOOD_CONDITION,
-    ).length;
-    this.stats.occupied = devices.filter(
-      (d) => d.status === DeviceStatus.OCCUPIED,
-    ).length;
-    this.stats.needsRepair = devices.filter(
-      (d) => d.status === DeviceStatus.NEEDS_REPAIR,
-    ).length;
-    this.stats.fair = devices.filter(
-      (d) => d.status === DeviceStatus.FAIR,
-    ).length;
-  }
-
-  /**
-   * Calcular estadísticas de órdenes
-   * @param orders Lista de órdenes
-   * @return void
-   */
-  private calculateOrderStats(orders: Order[]): void {
-    this.stats.totalOrders = orders.length;
-    this.stats.createdOrders = orders.filter(
-      (o) => o.state === 'CREATED',
-    ).length;
-    this.stats.inProgressOrders = orders.filter(
-      (o) => o.state === 'IN_PROGRESS',
-    ).length;
-    this.stats.despatchedOrders = orders.filter(
-      (o) => o.state === 'DISPATCHED',
-    ).length;
-    this.stats.finishedOrders = orders.filter(
-      (o) => o.state === 'FINISHED',
-    ).length;
-    this.stats.activeOrders =
-      this.stats.createdOrders +
-      this.stats.inProgressOrders +
-      this.stats.despatchedOrders;
-
-    // Calcular total de dispositivos en órdenes
-    this.stats.totalDevicesInOrders = orders.reduce(
-      (sum, order) => sum + order.items.length,
-      0,
-    );
-
-    // Calcular promedio de items por orden
-    this.stats.averageItemsPerOrder =
-      orders.length > 0
-        ? Math.round((this.stats.totalDevicesInOrders / orders.length) * 10) /
-          10
-        : 0;
-  }
-
-  /**
    * Obtener órdenes recientes basadas en la fecha de creación
    * @param orders Lista completa de órdenes
    * @param limit Cantidad de órdenes a retornar
@@ -490,35 +427,36 @@ export class DashboardComponent implements OnInit, OnDestroy {
    * Actualizar mensajes y conteos de alertas basados en las estadísticas actuales
    * @returns void
    */
-  private updateAlerts(): void {
-    this.alerts = [
+  getAlerts(stats: DashboardStatsType): Alerta[] {
+    console.log('Calculando alertas con stats:', stats);
+    return [
       {
         type: 'warning',
         icon: '⚠️',
         title: 'Dispositivos que necesitan reparación',
-        message: `${this.stats.needsRepair} dispositivo${this.stats.needsRepair !== 1 ? 's' : ''} requiere${this.stats.needsRepair === 1 ? '' : 'n'} atención`,
-        count: this.stats.needsRepair,
+        message: `${stats.needsRepair} dispositivo${stats.needsRepair !== 1 ? 's' : ''} requiere${stats.needsRepair === 1 ? '' : 'n'} atención`,
+        count: stats.needsRepair,
       },
       {
         type: 'info',
         icon: '📋',
         title: 'Órdenes creadas',
-        message: `${this.stats.createdOrders} orden${this.stats.createdOrders !== 1 ? 'es' : ''} esperando inicio`,
-        count: this.stats.createdOrders,
+        message: `${stats.createdOrders} orden${stats.createdOrders !== 1 ? 'es' : ''} esperando inicio`,
+        count: stats.createdOrders,
       },
       {
         type: 'primary',
         icon: '🔄',
         title: 'Órdenes en progreso',
-        message: `${this.stats.inProgressOrders} orden${this.stats.inProgressOrders !== 1 ? 'es' : ''} en proceso`,
-        count: this.stats.inProgressOrders,
+        message: `${stats.inProgressOrders} orden${stats.inProgressOrders !== 1 ? 'es' : ''} en proceso`,
+        count: stats.inProgressOrders,
       },
       {
         type: 'success',
         icon: '✅',
         title: 'Órdenes finalizadas',
-        message: `${this.stats.finishedOrders} orden${this.stats.finishedOrders !== 1 ? 'es' : ''} completadas`,
-        count: this.stats.finishedOrders,
+        message: `${stats.finishedOrders} orden${stats.finishedOrders !== 1 ? 'es' : ''} completadas`,
+        count: stats.finishedOrders,
       },
     ];
   }
@@ -641,9 +579,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   getAssigneeIcon(type: string): string {
     const iconMap: Record<string, string> = {
       GROUP: '👥',
-      INDIVIDUAL: '👤',
-      TECHNICIAN: '🔧',
-      TEAM: '🏢',
+      INDIVIDUAL: '👤'
     };
     return iconMap[type] || '📋';
   }

--- a/src/app/modules/private/dashboard/models/DashboardStats.ts
+++ b/src/app/modules/private/dashboard/models/DashboardStats.ts
@@ -38,3 +38,37 @@ export interface DashboardStatsGroups {
   totalGroups: number;
   activeGroups: number;
 }
+
+/**
+ * Interface que representa las estadísticas generales del dashboard, combinando dispositivos, órdenes, empleados y grupos.
+ * @since 2026-02-05
+ * @author Bunnystring
+ */
+export interface Alerta {
+  type: string;
+  icon: string;
+  title: string;
+  message: string;
+  count: number;
+}
+
+/**
+ * Interface que representa las estadísticas generales del dashboard, combinando dispositivos, órdenes, empleados y grupos.
+ * @since 2026-02-05
+ * @author Bunnystring
+ */
+export type DashboardStatsType = {
+  totalDevices: number;
+  goodCondition: number;
+  occupied: number;
+  needsRepair: number;
+  fair: number;
+  totalOrders: number;
+  activeOrders: number;
+  createdOrders: number;
+  inProgressOrders: number;
+  despatchedOrders: number;
+  finishedOrders: number;
+  totalDevicesInOrders: number;
+  averageItemsPerOrder: number;
+};

--- a/src/app/modules/private/devices/pages/devices/devices.component.ts
+++ b/src/app/modules/private/devices/pages/devices/devices.component.ts
@@ -105,15 +105,6 @@ export class DevicesComponent implements OnInit, OnDestroy {
   // Subject para manejar la destrucción del componente y evitar fugas de memoria
   private readonly destroy$ = new Subject<void>();
 
-  // Stats locales
-  stats = {
-    totalDevices: 0,
-    goodCondition: 0,
-    occupied: 0,
-    needsRepair: 0,
-    fair: 0,
-  };
-
   // Paginación
   page = 1;
   pageSize = 10;
@@ -184,7 +175,7 @@ export class DevicesComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.buttonsIsAvailable = true; 
+    this.buttonsIsAvailable = true;
     this.deviceError = false;
     this.deviceErrorMessage = '';
     this.devices$.next(resolved);

--- a/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.html
+++ b/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.html
@@ -1,6 +1,5 @@
 <div class="modal modal-open bg-transparent">
   <div class="modal-box bg-white/90 backdrop-blur-sm border border-blue-200 shadow-2xl rounded-xl relative max-w-2xl">
-    <!-- Icono decorativo arriba derecha -->
     <div class="absolute top-0 right-0 m-6 z-10 text-blue-200 pointer-events-none opacity-70">
       <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -92,7 +91,6 @@
             <span *ngIf="!orderForm.get('devicesIds')?.value.length"
               class="text-neutral-content opacity-50 text-sm">Nada seleccionado</span>
           </div>
-          <!-- Custom dropdown (sin DaisyUI dropdown, solo Angular control) -->
           <div class="relative w-full">
             <button type="button"
               class="select select-bordered w-full text-lg bg-white/70 flex justify-between items-center cursor-pointer px-4 py-2 transition-all border-blue-300"

--- a/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.html
+++ b/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.html
@@ -1,0 +1,154 @@
+<div class="modal modal-open bg-transparent">
+  <div class="modal-box bg-white/90 backdrop-blur-sm border border-blue-200 shadow-2xl rounded-xl relative max-w-2xl">
+    <!-- Icono decorativo arriba derecha -->
+    <div class="absolute top-0 right-0 m-6 z-10 text-blue-200 pointer-events-none opacity-70">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+          d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    </div>
+    <div class="px-8 py-10">
+      <h3 class="font-bold text-3xl mb-7 text-blue-700 tracking-tight flex items-center gap-3">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-7 w-7 text-blue-400" fill="none" viewBox="0 0 24 24"
+          stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+            d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
+        </svg>
+        {{ order ? 'Editar Orden' : 'Nueva Orden' }}
+      </h3>
+
+      <form [formGroup]="orderForm" (ngSubmit)="onSubmit()" class="space-y-6">
+        <!-- Descripción -->
+        <div>
+          <label class="label text-base font-semibold text-blue-700 mb-2">Descripción</label>
+          <div class="relative">
+            <input formControlName="description" type="text"
+              class="input input-bordered w-full pr-12 text-lg bg-white/70 focus:ring-2 focus:ring-blue-400 transition-all"
+              placeholder="Breve descripción" [class.input-error]="submitted && orderForm.get('description')?.invalid"
+              autocomplete="off" />
+            <svg *ngIf="orderForm.get('description')?.valid && orderForm.get('description')?.touched"
+              class="h-5 w-5 text-success absolute right-5 top-1/2 -translate-y-1/2" fill="none" stroke="currentColor"
+              stroke-width="2" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+            </svg>
+            <svg *ngIf="submitted && orderForm.get('description')?.invalid"
+              class="h-5 w-5 text-error absolute right-5 top-1/2 -translate-y-1/2" fill="none" stroke="currentColor"
+              stroke-width="2" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </div>
+          <div class="text-xs text-error mt-2 transition-all"
+            *ngIf="submitted && orderForm.get('description')?.hasError('whitespace')">No debe contener solo espacios
+            en blanco.</div>
+          <div class="text-xs text-error mt-2 transition-all"
+            *ngIf="submitted && orderForm.get('description')?.hasError('required')">Campo obligatorio.</div>
+        </div>
+        <!-- Tipo de asignación -->
+        <div>
+          <label class="label text-base font-semibold text-blue-700 mb-2">Tipo de asignación</label>
+          <select formControlName="assignedType" class="select select-bordered w-full text-lg bg-white/70">
+            <option value="" disabled selected>Selecciona tipo de asignación</option>
+            <option *ngFor="let tipo of assignedType" [value]="tipo.value">
+              {{ tipo.label }}
+            </option>
+          </select>
+          <div class="text-xs text-error mt-2" *ngIf="orderForm.get('assignedType')?.invalid && submitted">Selecciona
+            el tipo de asignación.</div>
+        </div>
+        <!-- Selector de grupos -->
+        <div *ngIf="orderForm.get('assignedType')?.value === 'GROUP'">
+          <label class="label text-base font-semibold text-blue-700 mb-2">Grupo responsable</label>
+          <select formControlName="assigneeId" class="select select-bordered w-full text-lg bg-white/70">
+            <option value="" disabled selected>Selecciona grupo</option>
+            <option *ngFor="let group of groups" [value]="group.id">{{ group.name }}</option>
+          </select>
+          <div class="text-xs text-error mt-2" *ngIf="orderForm.get('assigneeId')?.invalid && submitted">Selecciona un
+            grupo.</div>
+        </div>
+        <!-- Selector de empleados -->
+        <div *ngIf="orderForm.get('assignedType')?.value === 'EMPLOYEE'">
+          <label class="label text-base font-semibold text-blue-700 mb-2">Empleado responsable</label>
+          <select formControlName="assigneeId" class="select select-bordered w-full text-lg bg-white/70">
+            <option value="" disabled selected>Selecciona empleado</option>
+            <option *ngFor="let emp of employees" [value]="emp.id">{{ emp.fullName }}</option>
+          </select>
+          <div class="text-xs text-error mt-2" *ngIf="orderForm.get('assigneeId')?.invalid && submitted">Selecciona un
+            empleado.</div>
+        </div>
+        <!-- Multiselect dispositivos: custom dropdown -->
+        <div>
+          <label class="label text-base font-semibold text-blue-700 mb-2">Dispositivos a incluir</label>
+          <div class="flex flex-wrap gap-2 mb-2">
+            <ng-container *ngFor="let selectedId of orderForm.get('devicesIds')?.value">
+              <span
+                class="badge badge-lg px-3 py-1 bg-blue-100 text-blue-700 border border-blue-300 font-medium flex items-center cursor-pointer shadow">
+                {{ getDeviceName(selectedId) }}
+                <button type="button" class="ml-2 btn btn-xs btn-circle btn-outline btn-error border-none text-xs"
+                  (click)="removeDevice(selectedId)" aria-label="Quitar dispositivo">
+                  ✕
+                </button>
+              </span>
+            </ng-container>
+            <span *ngIf="!orderForm.get('devicesIds')?.value.length"
+              class="text-neutral-content opacity-50 text-sm">Nada seleccionado</span>
+          </div>
+          <!-- Custom dropdown (sin DaisyUI dropdown, solo Angular control) -->
+          <div class="relative w-full">
+            <button type="button"
+              class="select select-bordered w-full text-lg bg-white/70 flex justify-between items-center cursor-pointer px-4 py-2 transition-all border-blue-300"
+              (click)="showDeviceDropdown = !showDeviceDropdown">
+              <span class="text-blue-700 font-medium">Añadir dispositivo...</span>
+              <svg width="16" height="16" fill="none" class="text-blue-500">
+                <path d="M4 6l4 4 4-4" stroke="currentColor" stroke-width="2" />
+              </svg>
+            </button>
+            <div *ngIf="showDeviceDropdown"
+              class="absolute left-0 top-full mt-2 p-2 shadow bg-white/90 border border-blue-200 rounded-xl w-full z-50"
+              style="max-height:15rem;overflow-y:auto;">
+              <input [(ngModel)]="deviceSearch" [ngModelOptions]="{standalone: true}" (input)="filterDevices()"
+                type="text"
+                class="input input-sm input-bordered w-full mb-2 bg-white/90 focus:ring-2 focus:ring-blue-400"
+                placeholder="Buscar dispositivo..." />
+              <ul>
+                <li *ngFor="let dev of filteredDevices">
+                  <a (click)="addDevice(dev.id)"
+                    class="select select-bordered w-full text-lg bg-white/70 flex items-center justify-between px-4 py-2 cursor-pointer transition-all border-none hover:bg-blue-50 hover:text-blue-700 focus:bg-blue-100 rounded-lg">
+                    <span class="font-medium">{{ dev.name }}</span>
+                    <span class="text-xs text-blue-500">{{ dev.brand }}</span>
+                  </a>
+                </li>
+                <li *ngIf="filteredDevices.length === 0" class="text-center text-neutral-content opacity-60 py-2">Sin
+                  coincidencias</li>
+              </ul>
+              <!-- Cierra el menú -->
+              <button type="button" class="btn btn-sm btn-ghost w-full mt-2" (click)="showDeviceDropdown = false">
+                Cerrar
+              </button>
+            </div>
+          </div>
+          <div class="text-xs text-error mt-2" *ngIf="orderForm.get('devicesIds')?.invalid && submitted">
+            Selecciona al menos un dispositivo.
+          </div>
+        </div>
+        <!-- Botones -->
+        <div class="modal-action flex justify-center gap-4 mt-8">
+          <button type="button" class="btn btn-ghost btn-lg text-red-600 border-red-400" (click)="close.emit()">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" viewBox="0 0 24 24" fill="none"
+              stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+            Cancelar
+          </button>
+          <button type="submit" class="btn btn-primary btn-lg shadow-lg">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" viewBox="0 0 24 24" fill="none"
+              stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+            </svg>
+            {{ order ? 'Guardar cambios' : 'Crear orden' }}
+          </button>
+        </div>
+      </form>
+
+    </div>
+  </div>
+</div>

--- a/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.html
+++ b/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.html
@@ -146,7 +146,6 @@
           </button>
         </div>
       </form>
-
     </div>
   </div>
 </div>

--- a/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.ts
+++ b/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.ts
@@ -123,11 +123,11 @@ export class OrderCreateEditModalComponent
   }
 
   addDevice(deviceId: string) {
-  const selected = this.orderForm.get('devicesIds')?.value || [];
-  this.orderForm.get('devicesIds')?.setValue([...selected, deviceId]);
-  this.deviceSearch = '';
-  this.filterDevices();
-}
+    const selected = this.orderForm.get('devicesIds')?.value || [];
+    this.orderForm.get('devicesIds')?.setValue([...selected, deviceId]);
+    this.deviceSearch = '';
+    this.filterDevices();
+  }
 
   removeDevice(deviceId: string) {
     const selected = this.orderForm.controls['devicesIds'].value || [];
@@ -169,25 +169,47 @@ export class OrderCreateEditModalComponent
       this.filterDevices();
     });
   }
-
+  /**
+   * Maneja el evento de envío del formulario, validando los datos y emitiendo el resultado a través del Output 'save'.
+   * Si el formulario es inválido, se establece un mensaje de error y no se emite ningún evento.
+   * Si el formulario es válido, se construye un objeto OrderFormResult con los datos del formulario y se emite a través del Output 'save'.
+   * @returns void
+   */
   onSubmit(): void {
     this.submitted = true;
   }
 
+  /**
+   * Maneja el cambio en el tipo de asignación (empleado o grupo), limpiando el campo de selección correspondiente para evitar inconsistencias en el formulario.
+   * Se llama cada vez que el usuario cambia el valor del campo 'assignedType' en el formulario.
+   * @returns void
+   * @param event
+   */
   onAssignedTypeChange(event: any) {
     this.orderForm.patchValue({ assigneeId: '' });
   }
 
+  /**
+   * Obtiene el nombre del dispositivo a partir de su ID, buscando en la lista de dispositivos cargada en el componente. Si no se encuentra el dispositivo, devuelve 'Sin nombre'.
+   * Se utiliza para mostrar el nombre del dispositivo en la interfaz de usuario a partir de su ID almacenada en la orden.
+   * @param deviceId El ID del dispositivo.
+   * @returns El nombre del dispositivo o 'Sin nombre' si no se encuentra.
+   */
   getDeviceName(deviceId: string): string {
     const device = this.devices.find((d) => d.id === deviceId);
     return device ? device.name : 'Sin nombre';
   }
 
+  /**
+   * Maneja la selección de un dispositivo desde el dropdown personalizado, agregando el ID del dispositivo seleccionado al formulario y actualizando la lista de dispositivos filtrados.
+   * Se llama cada vez que el usuario selecciona un dispositivo del dropdown, y se encarga de mantener actualizado el estado del formulario y la lista de dispositivos disponibles para selección.
+   * @returns void
+   * @param deviceId El ID del dispositivo seleccionado.
+   */
   onSeleccionarDispositivo(deviceId: string) {
-  const seleccionados = this.orderForm.get('devicesIds')?.value || [];
-  this.orderForm.get('devicesIds')?.setValue([...seleccionados, deviceId]);
-  this.deviceSearch = '';
-  this.filterDevices(); // Este método sólo actualiza filteredDevices, que también puede estar en el template
-  // NO necesitas cd.detectChanges() si lo haces en este handler, Angular está listo para el cambio
-}
+    const seleccionados = this.orderForm.get('devicesIds')?.value || [];
+    this.orderForm.get('devicesIds')?.setValue([...seleccionados, deviceId]);
+    this.deviceSearch = '';
+    this.filterDevices();
+  }
 }

--- a/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.ts
+++ b/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.ts
@@ -1,30 +1,49 @@
+import { Device } from './../../../devices/models/device.model';
 import { DevicesService } from './../../../devices/services/devices.service';
-import { Component, OnChanges, OnDestroy, OnInit, Input, Output, EventEmitter } from '@angular/core';
-import { Order, OrderFormResult, OrderStateLabels,OrderStates } from '../../models/Orders';
+import {
+  Component,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Input,
+  Output,
+  EventEmitter,
+} from '@angular/core';
+import {
+  Order,
+  OrderFormResult,
+  OrderStateLabels,
+  OrderStates,
+} from '../../models/Orders';
 import { CommonModule } from '@angular/common';
-import { FormGroup } from '@angular/forms';
-import { Subject } from 'rxjs';
+import { FormGroup, FormsModule, Validators } from '@angular/forms';
+import { forkJoin, Subject } from 'rxjs';
 import { GroupsService } from '../../../groups/services/groups.service';
 import { EmployeesService } from '../../../employees/services/employees.service';
 import { FormBuilder } from '@angular/forms';
 import { ChangeDetectorRef, SimpleChanges } from '@angular/core';
+import { Employee } from '../../../employees/models/employe.model';
+import { Group } from '../../../groups/models/groups.model';
+import { noWhitespaceValidator } from '../../../../../core/utils/form-validators.utils';
+import { ReactiveFormsModule } from '@angular/forms';
 
 @Component({
   selector: 'app-order-create-edit-modal',
   templateUrl: './order-create-edit-modal.component.html',
   styleUrls: ['./order-create-edit-modal.component.css'],
-  imports: [CommonModule],
+  imports: [CommonModule, ReactiveFormsModule, FormsModule],
   standalone: true,
 })
-export class OrderCreateEditModalComponent implements OnInit, OnDestroy, OnChanges {
-
-    // Inputs y Outputs
+export class OrderCreateEditModalComponent
+  implements OnInit, OnDestroy, OnChanges
+{
+  // Inputs y Outputs
   @Input() order: Order | null = null;
   @Output() close = new EventEmitter<void>();
   @Output() save = new EventEmitter<OrderFormResult>();
 
   // Formulario y estado
-  deviceForm!: FormGroup;
+  orderForm!: FormGroup;
   submitted = false;
   OrderStates = OrderStates;
   OrderStatesLabels = OrderStateLabels;
@@ -34,13 +53,25 @@ export class OrderCreateEditModalComponent implements OnInit, OnDestroy, OnChang
   // Para manejar desuscripciones
   private destroy$ = new Subject<void>();
 
+  devices: Device[] = [];
+  employees: Employee[] = [];
+  groups: Group[] = [];
+  assignedType = [
+    { label: 'Empleado', value: 'EMPLOYEE' },
+    { label: 'Grupo', value: 'GROUP' },
+  ];
+
+  showDeviceDropdown = false;
+  deviceSearch = '';
+  filteredDevices: Device[] = [];
+
   constructor(
     private devicesService: DevicesService,
     private groupsService: GroupsService,
     private employeesService: EmployeesService,
     private fb: FormBuilder,
     private cd: ChangeDetectorRef,
-  ) { }
+  ) {}
 
   ngOnInit() {
     this.initParameters();
@@ -56,6 +87,7 @@ export class OrderCreateEditModalComponent implements OnInit, OnDestroy, OnChang
     if (changes['order'] && !changes['order'].firstChange) {
       this.initParameters();
       this.initForm();
+      this.filterDevices();
     }
   }
 
@@ -65,7 +97,44 @@ export class OrderCreateEditModalComponent implements OnInit, OnDestroy, OnChang
    * @returns void
    */
   private initParameters(): void {
+    forkJoin([
+      this.devicesService.getAllDevices(),
+      this.groupsService.getAllGroups(),
+      this.employeesService.getAllEmployees(),
+    ]).subscribe(([devices, groups, employees]) => {
+      this.devices = devices;
+      this.groups = groups;
+      this.employees = employees;
+      this.filterDevices();
+      this.cd.detectChanges();
+    });
+  }
 
+  filterDevices() {
+    const selected = this.orderForm.get('devicesIds')?.value || [];
+    const search = (this.deviceSearch || '').toLowerCase().trim();
+    this.filteredDevices = this.devices.filter(
+      (d) =>
+        !selected.includes(d.id) &&
+        (!search ||
+          d.name?.toLowerCase().includes(search) ||
+          (d.brand && d.brand.toLowerCase().includes(search))),
+    );
+  }
+
+  addDevice(deviceId: string) {
+  const selected = this.orderForm.get('devicesIds')?.value || [];
+  this.orderForm.get('devicesIds')?.setValue([...selected, deviceId]);
+  this.deviceSearch = '';
+  this.filterDevices();
+}
+
+  removeDevice(deviceId: string) {
+    const selected = this.orderForm.controls['devicesIds'].value || [];
+    this.orderForm.controls['devicesIds'].setValue(
+      selected.filter((id: string) => id !== deviceId),
+    );
+    this.filterDevices();
   }
 
   /**
@@ -74,6 +143,51 @@ export class OrderCreateEditModalComponent implements OnInit, OnDestroy, OnChang
    * @returns void
    */
   private initForm(): void {
+    this.orderForm = this.fb.group({
+      description: [
+        this.order?.description || '',
+        [Validators.required, noWhitespaceValidator()],
+      ],
+      assignedType: [this.order?.assigneeType || '', [Validators.required]],
+      assigneeId: [this.order?.assigneeId || '', [Validators.required]],
+      devicesIds: [
+        this.order?.items.map((d) => d.deviceId) || [],
+        [Validators.required],
+      ],
+    });
 
+    // Inicializar el filtrado de dispositivos al crear el form
+    this.filterDevices();
+
+    // Opcional: si cambia el tipo de asignación, limpia el selector correspondiente
+    this.orderForm.get('assignedType')?.valueChanges.subscribe((val) => {
+      this.orderForm.patchValue({ assigneeId: '' });
+    });
+
+    // Opcional: reactualiza lista filtrada de dispositivos si cambia selección
+    this.orderForm.get('devicesIds')?.valueChanges.subscribe(() => {
+      this.filterDevices();
+    });
   }
+
+  onSubmit(): void {
+    this.submitted = true;
+  }
+
+  onAssignedTypeChange(event: any) {
+    this.orderForm.patchValue({ assigneeId: '' });
+  }
+
+  getDeviceName(deviceId: string): string {
+    const device = this.devices.find((d) => d.id === deviceId);
+    return device ? device.name : 'Sin nombre';
+  }
+
+  onSeleccionarDispositivo(deviceId: string) {
+  const seleccionados = this.orderForm.get('devicesIds')?.value || [];
+  this.orderForm.get('devicesIds')?.setValue([...seleccionados, deviceId]);
+  this.deviceSearch = '';
+  this.filterDevices(); // Este método sólo actualiza filteredDevices, que también puede estar en el template
+  // NO necesitas cd.detectChanges() si lo haces en este handler, Angular está listo para el cambio
+}
 }

--- a/src/app/modules/private/orders/pages/orders/orders.component.html
+++ b/src/app/modules/private/orders/pages/orders/orders.component.html
@@ -1,7 +1,7 @@
 <div *ngIf="loading$ | async" class="toast toast-top toast-center z-50">
   <div class="alert alert-info gap-2">
     <span class="loading loading-spinner loading-sm"></span>
-    <span>Cargando órdenes...</span>
+    <span>Actualizando datos...</span>
   </div>
 </div>
 
@@ -25,7 +25,7 @@
         </div>
       </div>
       <button class="btn btn-primary btn-lg gap-3 shadow-lg" (click)="showCreateModal = true"
-      [disabled]="!buttonsIsAvailable">
+        [disabled]="!buttonsIsAvailable">
         <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
         </svg>
@@ -34,55 +34,60 @@
     </div>
 
     <!-- Stats resumen con iconos SVG -->
-    <div class="grid grid-cols-2 md:grid-cols-4 gap-6 mb-8">
-      <div class="stat shadow-md rounded-lg">
-        <div class="stat-figure text-primary">
-          <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round"
-              d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
-          </svg>
+    <ng-container *ngIf="filteredOrders$ | async as filteredOrders">
+      <ng-container *ngIf="getStates(filteredOrders) as stats">
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-6 mb-8">
+          <div class="stat shadow-md rounded-lg">
+            <div class="stat-figure text-primary">
+              <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
+              </svg>
+            </div>
+            <div class="stat-title text-base font-semibold">Total</div>
+            <div class="stat-value text-primary text-2xl">{{ stats.totalOrders }}</div>
+            <div class="stat-desc">órdenes</div>
+          </div>
+          <div class="stat shadow-md rounded-lg">
+            <div class="stat-figure text-success">
+              <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4" />
+              </svg>
+            </div>
+            <div class="stat-title text-base font-semibold">Creadas</div>
+            <div class="stat-value text-success text-2xl">{{ stats.created }}</div>
+            <div class="stat-desc">
+              {{ (stats.totalOrders ? (stats.created / stats.totalOrders * 100) : 0) | number:'1.0-0' }}%
+            </div>
+          </div>
+          <div class="stat shadow-md rounded-lg">
+            <div class="stat-figure text-warning">
+              <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+              </svg>
+            </div>
+            <div class="stat-title text-base font-semibold">En progreso</div>
+            <div class="stat-value text-warning text-2xl">{{ stats.inProgress }}</div>
+            <div class="stat-desc">
+              {{ (stats.totalOrders ? (stats.inProgress / stats.totalOrders * 100) : 0) | number:'1.0-0' }}%
+            </div>
+          </div>
+          <div class="stat shadow-md rounded-lg">
+            <div class="stat-figure text-success">
+              <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <circle cx="12" cy="12" r="10" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4" />
+              </svg>
+            </div>
+            <div class="stat-title text-base font-semibold">Finalizadas</div>
+            <div class="stat-value text-success text-2xl">{{ stats.finished }}</div>
+            <div class="stat-desc">
+              {{ (stats.totalOrders ? (stats.finished / stats.totalOrders * 100) : 0) | number:'1.0-0' }}%
+            </div>
+          </div>
         </div>
-        <div class="stat-title text-base font-semibold">Total</div>
-        <div class="stat-value text-primary text-2xl">{{ stats.totalOrders }}</div>
-        <div class="stat-desc">órdenes</div>
-      </div>
-      <div class="stat shadow-md rounded-lg">
-        <div class="stat-figure text-success">
-          <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4" />
-          </svg>
-        </div>
-        <div class="stat-title text-base font-semibold">Creadas</div>
-        <div class="stat-value text-success text-2xl">{{ stats.created }}</div>
-        <div class="stat-desc">{{ (stats.totalOrders ? (stats.created / stats.totalOrders * 100) : 0) | number:'1.0-0'
-          }}%
-        </div>
-      </div>
-      <div class="stat shadow-md rounded-lg">
-        <div class="stat-figure text-warning">
-          <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
-          </svg>
-        </div>
-        <div class="stat-title text-base font-semibold">En progreso</div>
-        <div class="stat-value text-warning text-2xl">{{ stats.inProgress }}</div>
-        <div class="stat-desc">{{ (stats.totalOrders ? (stats.inProgress / stats.totalOrders * 100) : 0) |
-          number:'1.0-0'
-          }}%</div>
-      </div>
-      <div class="stat shadow-md rounded-lg">
-        <div class="stat-figure text-success">
-          <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-            <circle cx="12" cy="12" r="10" />
-            <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4" />
-          </svg>
-        </div>
-        <div class="stat-title text-base font-semibold">Finalizadas</div>
-        <div class="stat-value text-success text-2xl">{{ stats.finished }}</div>
-        <div class="stat-desc">{{ (stats.totalOrders ? (stats.finished / stats.totalOrders * 100) : 0) | number:'1.0-0'
-          }}%</div>
-      </div>
-    </div>
+      </ng-container>
+    </ng-container>
 
     <!-- FILTROS -->
     <div class="flex flex-row flex-wrap items-center gap-4 mb-4">
@@ -246,13 +251,13 @@
                   </span>
                 </div>
               </td>
-              <td>
+              <td class="justify-center text-center">
                 <span class="badge badge-outline badge-md px-3 bg-gray-100 text-gray-700 font-medium">
                   {{ order.assigneeType | titlecase }}
                 </span>
               </td>
               <td>
-                <span class="badge badge-outline badge-md px-3 bg-blue-100 text-blue-900 font-medium">
+                <span class="badge badge-outline px-3 py-2 rounded-full bg-blue-50 text-blue-800 font-semibold flex items-center whitespace-nowrap overflow-hidden truncate">
                   {{ order.createdAt | date }}
                 </span>
               </td>

--- a/src/app/modules/private/orders/pages/orders/orders.component.ts
+++ b/src/app/modules/private/orders/pages/orders/orders.component.ts
@@ -134,6 +134,23 @@ export class OrdersComponent implements OnInit, OnDestroy {
   // Flag para controlar la disponibilidad de los botones de acción (crear, editar, eliminar)
   buttonsIsAvailable = true;
 
+  public getStates(orders: Order[]) {
+    const totalOrders = orders.length;
+    const created = orders.filter(
+      (o) => o.state === OrderStates.CREATED,
+    ).length;
+    const inProgress = orders.filter(
+      (o) => o.state === OrderStates.IN_PROGRESS,
+    ).length;
+    const dispatched = orders.filter(
+      (o) => o.state === OrderStates.DISPATCHED,
+    ).length;
+    const finished = orders.filter(
+      (o) => o.state === OrderStates.FINISHED,
+    ).length;
+    return { totalOrders, created, inProgress, dispatched, finished };
+  }
+
   constructor(
     private ordersService: OrdersService,
     private loadingService: LoadingService,
@@ -271,8 +288,6 @@ export class OrdersComponent implements OnInit, OnDestroy {
       .subscribe({
         next: (orders) => {
           this.orders$.next(orders);
-          console.log('Órdenes cargadas:', orders);
-          this.updateStates(orders);
         },
         error: (err) => {
           console.error('Error al cargar órdenes:', err);
@@ -287,21 +302,6 @@ export class OrdersComponent implements OnInit, OnDestroy {
    * Actualiza las estadísticas de órdenes según su estado.
    * @param orders Lista de órdenes a procesar
    */
-  updateStates(orders: Order[]) {
-    this.stats.totalOrders = orders.length;
-    this.stats.created = orders.filter(
-      (o) => o.state === OrderStates.CREATED,
-    ).length;
-    this.stats.inProgress = orders.filter(
-      (o) => o.state === OrderStates.IN_PROGRESS,
-    ).length;
-    this.stats.dispatched = orders.filter(
-      (o) => o.state === OrderStates.DISPATCHED,
-    ).length;
-    this.stats.finished = orders.filter(
-      (o) => o.state === OrderStates.FINISHED,
-    ).length;
-  }
 
   /**
    * Calcula el número total de páginas para la paginación según el total de órdenes filtradas y el tamaño de página


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción

- **Refactorización total de la lógica de dashboard**: Unificación de la suscripción a los datos del dashboard con un solo async pipe; ahora todo el render depende de `dashboardStats$`, evitando doblescripciones y race conditions.
- **Refactorización de alertas**: Las alertas ahora se calculan de manera síncrona a partir de los datos de stats del dashboard (función `getAlerts(stats)` en el componente), eliminando problemas de reactividad y doble observable.
- **Corrección y estandarización de la visualización de stats**: Los “stats cards” se muestran siempre en el orden correcto, primero las de dispositivos, luego las de órdenes.
- **Mejoras visuales y de UX**: Los SVG de cada stat ahora son representativos y homogéneos (usando Heroicons).
- **Creación del modal para crear órdenes**: Se implementa, un modal reutilizable para la creación de nuevas órdenes, integrado con el flujo de refresco y actualización de stats.
- **Robustez en el manejo de errores**: Mejora del manejo de errores individuales y globales para dispositivos/órdenes.
- **Refactor general y documentación**: Orden, tipos y documentación inline mejorados.


## ¿Qué tipo de cambio es?
- [ ] Bugfix 🐞
- [x] Feature ✨
- [x] Refactor 🔧
- [x] Documentación 📚
- [ ] Otro

## ¿Cómo probar estos cambios?
- Ir al dashboard principal.
- Visualizar stats: primero deben mostrarse los stats de dispositivos, luego los de órdenes, luego las órdenes recientes, luego los dispositivos en órdenes.
- Los “alerts” deben aparecer correctamente, siempre alineados a los stats actuales (refresca varias veces y prueba recargar datos).
- Hacer clic en “Crear Orden” — verifica que el modal para crear órdenes funciona, permite ingresar datos, y al cerrar/crear, el modulo de ordenes se actualiza.
- Probar desconexión/fallos: Los mensajes de error figuran sólo cuando corresponde.
- Verificar que los SVG de stats sean visualmente significativos.

## Checklist
- [x] El código compila y pasa los tests
- [x] La documentación está actualizada (si aplica)
- [x] No hay warnings nuevos
- [x] Revisé el formato y convenciones de código

## Screenshots (si aplica)
<!-- Adjunta capturas si hay cambios visuales. -->

## Issue relacionada
<!-- Si hay issues asociadas, referencia: closes #123 -->

## Notas para el revisor
<!-- Información extra útil para quien revisa el PR -->
