### PR TITLE
feat(issue-13): Se implementa modal que crea la orden y sus restricciones para grupos empleados y dispositivos

### DIFF
--- a/src/app/modules/private/dashboard/dashboard.component.ts
+++ b/src/app/modules/private/dashboard/dashboard.component.ts
@@ -428,7 +428,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
    * @returns void
    */
   getAlerts(stats: DashboardStatsType): Alerta[] {
-    console.log('Calculando alertas con stats:', stats);
     return [
       {
         type: 'warning',

--- a/src/app/modules/private/employees/models/employe.model.ts
+++ b/src/app/modules/private/employees/models/employe.model.ts
@@ -22,9 +22,9 @@ export interface CreateEmployeeRq {
 /**
  * Modelo que representa los estados posibles de un empleado
  */
-export interface EmployeeStatus {
-  ACTIVE: 'ACTIVE';
-  INACTIVE: 'INACTIVE';
+export enum EmployeeStatus {
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
 }
 
 /**

--- a/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.ts
+++ b/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.ts
@@ -1,4 +1,4 @@
-import { Device } from './../../../devices/models/device.model';
+import { Device, DevicesBatchRq, DeviceStatus } from './../../../devices/models/device.model';
 import { DevicesService } from './../../../devices/services/devices.service';
 import {
   Component,
@@ -10,6 +10,7 @@ import {
   EventEmitter,
 } from '@angular/core';
 import {
+  CreateOrderRequest,
   Order,
   OrderFormResult,
   OrderStateLabels,
@@ -17,7 +18,16 @@ import {
 } from '../../models/Orders';
 import { CommonModule } from '@angular/common';
 import { FormGroup, FormsModule, Validators } from '@angular/forms';
-import { forkJoin, Subject } from 'rxjs';
+import {
+  forkJoin,
+  Subject,
+  switchMap,
+  of,
+  tap,
+  map,
+  takeUntil,
+  finalize,
+} from 'rxjs';
 import { GroupsService } from '../../../groups/services/groups.service';
 import { EmployeesService } from '../../../employees/services/employees.service';
 import { FormBuilder } from '@angular/forms';
@@ -26,6 +36,9 @@ import { Employee } from '../../../employees/models/employe.model';
 import { Group } from '../../../groups/models/groups.model';
 import { noWhitespaceValidator } from '../../../../../core/utils/form-validators.utils';
 import { ReactiveFormsModule } from '@angular/forms';
+import { OrdersService } from '../../services/orders.service';
+import { toast } from 'ngx-sonner';
+import { EmployeeStatus } from '../../../employees/models/employe.model';
 
 @Component({
   selector: 'app-order-create-edit-modal',
@@ -71,6 +84,7 @@ export class OrderCreateEditModalComponent
     private employeesService: EmployeesService,
     private fb: FormBuilder,
     private cd: ChangeDetectorRef,
+    private ordersService: OrdersService,
   ) {}
 
   ngOnInit() {
@@ -92,8 +106,9 @@ export class OrderCreateEditModalComponent
   }
 
   /**
-   * Inicializa los parámetros necesarios para el formulario, como listas de dispositivos, grupos y empleados, a partir de los servicios correspondientes.
-   * Esta función se llama tanto en ngOnInit como en ngOnChanges para asegurar que los datos estén actualizados al abrir el modal o al cambiar la orden a editar.
+   * Inicializa los parámetros necesarios para el formulario, cargando dispositivos, grupos y empleados desde sus respectivos servicios.
+   * Luego, si hay dispositivos cargados, realiza una consulta adicional para obtener el estado de asignación activa de cada dispositivo y actualizar la lista de dispositivos con esta información.
+   * Finalmente, actualiza el estado del componente con los datos cargados y filtrados, y fuerza la detección de cambios para reflejar los cambios en la interfaz de usuario.
    * @returns void
    */
   private initParameters(): void {
@@ -101,15 +116,66 @@ export class OrderCreateEditModalComponent
       this.devicesService.getAllDevices(),
       this.groupsService.getAllGroups(),
       this.employeesService.getAllEmployees(),
-    ]).subscribe(([devices, groups, employees]) => {
-      this.devices = devices;
-      this.groups = groups;
-      this.employees = employees;
-      this.filterDevices();
-      this.cd.detectChanges();
-    });
+    ])
+      .pipe(
+        tap(([devices, groups, employees]) => {
+          // Guarda los resultados de los servicios
+          this.devices = devices;
+          this.groups = groups;
+          this.employees = employees;
+          this.filterDevices();
+          this.cd.detectChanges();
+        }),
+        switchMap(([devices, groups, employees]) => {
+          if (devices.length > 0) {
+            const rq: DevicesBatchRq = {
+              ids: devices.map((device) => device.id),
+            };
+            return this.devicesService.hasActiveAssignmentBatch(rq).pipe(
+              map((assignments) => {
+                const newDevices = devices.map((device): Device => {
+                  const found = assignments.find(
+                    (a) => a.deviceId === device.id,
+                  );
+                  return {
+                    ...device,
+                    assignmentActive: found ? found.active : false,
+                    selected: false,
+                  } as Device;
+                });
+                const filteredDevices = this.validateDevices(newDevices);
+                return [filteredDevices, groups, employees] as [
+                  Device[],
+                  any,
+                  any,
+                ];
+              }),
+            );
+          } else {
+            return of([[], groups, employees] as [Device[], any, any]);
+          }
+        }),
+        tap(([devices, groups, employees]) => {
+          this.groups = this.validateGroups(groups);
+          this.employees = employees;
+          this.filterDevices();
+          this.cd.detectChanges();
+        }),
+      )
+      .subscribe(([devices, groups, employees]) => {
+        this.devices = devices;
+        this.groups = this.validateGroups(groups);
+        this.employees = employees;
+        this.filterDevices();
+        this.cd.detectChanges();
+      });
   }
 
+  /**
+   * Filtra la lista de dispositivos disponibles para asignar a la orden, excluyendo los dispositivos ya seleccionados y aplicando un filtro de búsqueda por nombre o marca.
+   * Se llama cada vez que se actualiza la selección de dispositivos o el término de búsqueda, para mantener la lista de dispositivos disponibles siempre actualizada y relevante para el usuario.
+   * @returns void
+   */
   filterDevices() {
     const selected = this.orderForm.get('devicesIds')?.value || [];
     const search = (this.deviceSearch || '').toLowerCase().trim();
@@ -122,6 +188,12 @@ export class OrderCreateEditModalComponent
     );
   }
 
+  /**
+   * Agrega un dispositivo seleccionado al formulario, actualizando la lista de dispositivos seleccionados y filtrando la lista de dispositivos disponibles para reflejar el cambio.
+   * Se llama cada vez que el usuario selecciona un dispositivo del dropdown, y se encarga de mantener actualizado el estado del formulario y la lista de dispositivos disponibles para selección.
+   * @returns void
+   * @param deviceId
+   */
   addDevice(deviceId: string) {
     const selected = this.orderForm.get('devicesIds')?.value || [];
     this.orderForm.get('devicesIds')?.setValue([...selected, deviceId]);
@@ -129,6 +201,12 @@ export class OrderCreateEditModalComponent
     this.filterDevices();
   }
 
+  /**
+   * Elimina un dispositivo de la selección actual en el formulario, actualizando la lista de dispositivos seleccionados y filtrando la lista de dispositivos disponibles para reflejar el cambio.
+   * Se llama cada vez que el usuario decide eliminar un dispositivo de la selección actual, y se encarga de mantener actualizado el estado del formulario y la lista de dispositivos disponibles para selección.
+   * @returns void
+   * @param deviceId
+   */
   removeDevice(deviceId: string) {
     const selected = this.orderForm.controls['devicesIds'].value || [];
     this.orderForm.controls['devicesIds'].setValue(
@@ -172,11 +250,56 @@ export class OrderCreateEditModalComponent
   /**
    * Maneja el evento de envío del formulario, validando los datos y emitiendo el resultado a través del Output 'save'.
    * Si el formulario es inválido, se establece un mensaje de error y no se emite ningún evento.
-   * Si el formulario es válido, se construye un objeto OrderFormResult con los datos del formulario y se emite a través del Output 'save'.
+   * Si el formulario es válido, se construye un objeto CreateOrderRequest con los datos del formulario y se emite a través del Output 'save'.
    * @returns void
    */
   onSubmit(): void {
     this.submitted = true;
+    this.formError = '';
+
+    // Validación: si es edición, verifica que haya cambios
+    if (this.order && !this.hasChanges()) {
+      toast.warning('No se detectaron cambios en la orden');
+      this.formLoading = false;
+      this.cd.markForCheck();
+      return;
+    }
+    if (this.orderForm.invalid) return;
+    this.formLoading = true;
+    this.cd.markForCheck();
+    const formValue = this.orderForm.value;
+    const isEdit = !!this.order;
+    const result: CreateOrderRequest = {
+      description: formValue.description.trim(),
+      assigneeType: formValue.assignedType,
+      assigneeId: formValue.assigneeId,
+      devicesIds: formValue.devicesIds,
+    };
+    const op$ = this.order
+      ? this.ordersService.updateOrder(this.order.id, result)
+      : this.ordersService.createOrder(result);
+    op$
+      .pipe(
+        takeUntil(this.destroy$),
+        finalize(() => {
+          this.formLoading = false;
+          this.cd.markForCheck();
+        }),
+      )
+      .subscribe({
+        next: (order: Order) => {
+          this.save.emit({ order, mode: isEdit ? 'edit' : 'create' });
+        },
+        error: (err) => {
+          const msg =
+            err?.error?.message || err?.message || 'Error al guardar la orden';
+
+          this.formError = msg;
+          toast.error('Error al guardar la orden', {
+            description: msg,
+          });
+        },
+      });
   }
 
   /**
@@ -211,5 +334,47 @@ export class OrderCreateEditModalComponent
     this.orderForm.get('devicesIds')?.setValue([...seleccionados, deviceId]);
     this.deviceSearch = '';
     this.filterDevices();
+  }
+
+  /**
+   * Valida la lista de dispositivos para asegurarse de que solo se muestren aquellos que no tienen una asignación activa y que están en buen estado, filtrando la lista original de dispositivos y devolviendo solo los válidos para asignar a una orden.
+   * Se utiliza para mantener la integridad de los datos y evitar que se asignen dispositivos que no están disponibles o que podrían causar problemas en la gestión de órdenes.
+   * @returns Device[] - Lista de dispositivos válidos para asignar a una orden.
+   */
+  validateDevices(devices: Device[]): Device[] {
+    return devices
+      .filter((d) => !d.assignmentActive)
+      .filter((d) => d.status === DeviceStatus.GOOD_CONDITION);
+  }
+
+  /**
+   * Verifica si hay cambios en el formulario comparado con los valores originales de la orden
+   * Si no hay orden (creación), siempre retorna true para permitir el envío
+   * Compara cada campo del formulario con la orden original para detectar cambios
+   * @returns boolean - true si hay cambios, false si no hay cambios
+   */
+  private hasChanges(): boolean {
+    if (!this.order) return true;
+    const current = this.orderForm.value;
+    return (
+      current.description !== this.order.description ||
+      current.devicesIds !== this.order.items ||
+      current.assigneesIds !== this.order.assigneeId ||
+      current.assigneeType !== this.order.assigneeType
+    );
+  }
+
+  /**
+   * Valida la lista de grupos para asegurarse de que solo se muestren aquellos que tienen empleados activos asignados, filtrando la lista original de grupos y devolviendo solo los válidos para asignar a una orden.
+   * Se utiliza para mantener la integridad de los datos y evitar que se asignen grupos que no tienen empleados activos, lo que podría causar problemas en la gestión de órdenes.
+   * @param groups - Lista de grupos a validar.
+   * @returns Group[] - Lista de grupos válidos para asignar a una orden.
+   */
+  validateGroups(groups: Group[]): Group[] {
+    return groups.filter(
+      (group) =>
+        Array.isArray(group.employees) &&
+        group.employees.some((employee) => employee.status === EmployeeStatus.ACTIVE),
+    );
   }
 }

--- a/src/app/modules/private/orders/services/orders.service.ts
+++ b/src/app/modules/private/orders/services/orders.service.ts
@@ -49,4 +49,14 @@ export class OrdersService {
       return this.apiService.putFormData<Order>(`/orders/${id}/state`, formData );
     }
 
+    /**
+     * Actualiza una orden existente
+     * @param id
+     * @param order
+     * @returns
+     */
+    updateOrder(id: string, order: Partial<CreateOrderRequest>): Observable<Order> {
+      return this.apiService.put<Order>(`/orders/${id}`, order);
+    }
+
 }


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción

- Se actualizó la lógica de validación para la asignación de dispositivos y grupos en el formulario de órdenes.  
- **Los dispositivos** solo se muestran en la lista si están en buen estado (`GOOD_CONDITION`) y no tienen una asignación activa.
- **Los grupos** solo aparecen si tienen al menos un empleado con estado `ACTIVE` en su propiedad `employees`.
- Se finaliza lógica y consumo del servicio que crea una Orden.

## ¿Qué tipo de cambio es?
- [x] Bugfix 🐞
- [x] Feature ✨
- [x] Refactor 🔧
- [x] Documentación 📚
- [ ] Otro

## ¿Cómo probar estos cambios?

- Abrir el formulario de crear/editar orden.
- Verificar  que **la lista de dispositivos** excluya los que tengan asignación activa o no estén en buen estado.
- Verificar que **la lista de grupos** solo incluya los que tienen al menos un empleado activo.
- Probar casos límite: grupos vacíos, sólo inactivos, dispositivos con y sin asignación activa.

## Checklist
- [x] El código compila y pasa los tests
- [x] La documentación está actualizada (si aplica)
- [x] No hay warnings nuevos
- [x] Revisé el formato y convenciones de código

## Screenshots (si aplica)
<!-- Adjunta capturas si hay cambios visuales. -->

## Issue relacionada
<!-- Si hay issues asociadas, referencia: closes #123 -->

## Notas para el revisor
<!-- Información extra útil para quien revisa el PR -->
