### PR TITLE
Merge Main to Dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@angular/platform-browser": "^21.2.12",
     "@angular/platform-browser-dynamic": "^21.2.12",
     "@angular/router": "^21.2.12",
+    "@ngrx/signals": "^21.1.0",
     "lottie-web": "^5.13.0",
     "ngx-lottie": "^12.0.0",
     "ngx-sonner": "^3.1.0",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,29 +1,22 @@
 import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
+      providers: [provideRouter([])],
     }).compileComponents();
   });
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
+    expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it(`should have the 'infragest-frontend' title`, () => {
+  it(`debe tener el título 'infragest-frontend'`, () => {
     const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('infragest-frontend');
-  });
-
-  it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, infragest-frontend');
+    expect(fixture.componentInstance.title).toEqual('infragest-frontend');
   });
 });

--- a/src/app/core/guards/auth.guards.ts
+++ b/src/app/core/guards/auth.guards.ts
@@ -33,20 +33,12 @@ export const authGuard: CanActivateFn = (route, state) => {
 
   // Si el token ha expirado o está por expirar, intentar refrescarlo
   if (authService.isTokenExpired() || authService.isTokenExpiringSoon()) {
-    /* console.warn(
-      `⚠️ AuthGuard: Token ${authService.isTokenExpired() ? 'expirado' : 'próximo a expirar'} ` +
-        `(${minutesRemaining}m ${secondsRemaining}s restantes), intentando refrescar...`,
-    ); */
-
     return authService.refreshToken().pipe(
       map(() => {
-        // console.log('✅ Token refrescado exitosamente');
         return true;
       }),
       catchError((error) => {
         console.error('❌ Error al refrescar token:', error);
-        // console.log('🔄 Redirigiendo a login con returnUrl:', state.url);
-
         router.navigate(['/auth/login'], {
           queryParams: { returnUrl: state.url },
         });

--- a/src/app/core/interceptors/auth.interceptor.ts
+++ b/src/app/core/interceptors/auth.interceptor.ts
@@ -48,13 +48,9 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
         !req.url.includes('/auth/refresh') &&
         authService.getRefreshToken()
       ) {
-        // console.warn('⚠️ Error 401 detectado, intentando refrescar token...');
-
         // Intentar refrescar el token
         return authService.refreshToken().pipe(
           switchMap((response) => {
-            // console.log('✅ Token refrescado exitosamente');
-
             // Clonar la petición original con el nuevo token
             const newToken = response.accessToken;
             const retryReq = req.clone({
@@ -62,8 +58,6 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
                 Authorization: `Bearer ${newToken}`,
               },
             });
-
-            // console.log('🔄 Reintentando petición original...');
             // Reintentar la petición original con el nuevo token
             return next(retryReq);
           }),

--- a/src/app/layouts/private/private-layout/private-layout.component.spec.ts
+++ b/src/app/layouts/private/private-layout/private-layout.component.spec.ts
@@ -1,23 +1,23 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { PrivateLayoutComponent } from './private-layout.component';
 
 describe('PrivateLayoutComponent', () => {
-  let component: PrivateLayoutComponent;
-  let fixture: ComponentFixture<PrivateLayoutComponent>;
-
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PrivateLayoutComponent]
-    })
-    .compileComponents();
-
-    fixture = TestBed.createComponent(PrivateLayoutComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+      imports: [PrivateLayoutComponent],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    const fixture = TestBed.createComponent(PrivateLayoutComponent);
+    expect(fixture.componentInstance).toBeTruthy();
   });
 });

--- a/src/app/layouts/public/public-layout/public-layout.component.spec.ts
+++ b/src/app/layouts/public/public-layout/public-layout.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 
 import { PublicLayoutComponent } from './public-layout.component';
 
@@ -8,9 +9,9 @@ describe('PublicLayoutComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PublicLayoutComponent]
-    })
-    .compileComponents();
+      imports: [PublicLayoutComponent],
+      providers: [provideRouter([])],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(PublicLayoutComponent);
     component = fixture.componentInstance;

--- a/src/app/modules/private/dashboard/dashboard.component.html
+++ b/src/app/modules/private/dashboard/dashboard.component.html
@@ -1,5 +1,5 @@
 <!-- Toast de Loading -->
-@if (loading$ | async) {
+@if (isLoading()) {
   <div class="toast toast-top toast-center z-50">
     <div class="alert alert-info gap-2">
       <span class="loading loading-spinner loading-sm"></span>
@@ -9,13 +9,13 @@
 }
 
 <!-- Error de Dispositivos -->
-@if (deviceError) {
+@if (deviceError()) {
   <div class="alert alert-warning shadow-lg mb-4">
     <!-- ...icono y mensaje... -->
     <h3 class="font-bold">Error al cargar dispositivos</h3>
-    <div class="text-sm">{{ deviceErrorMessage }}</div>
-    <button class="btn btn-sm btn-ghost gap-2" (click)="retryDevices()" [disabled]="isRetrying">
-      @if (isRetrying) {
+    <div class="text-sm">{{ deviceErrorMessage() }}</div>
+    <button class="btn btn-sm btn-ghost gap-2" (click)="retryDevices()" [disabled]="isRetrying()">
+      @if (isRetrying()) {
         <span class="loading loading-spinner loading-xs"></span>
       }
       Reintentar
@@ -23,13 +23,13 @@
   </div>
 }
 <!-- Error de Órdenes -->
-@if (orderError) {
+@if (orderError()) {
   <div class="alert alert-warning shadow-lg mb-4">
     <!-- ...icono y mensaje... -->
     <h3 class="font-bold">Error al cargar órdenes</h3>
-    <div class="text-sm">{{ orderErrorMessage }}</div>
-    <button class="btn btn-sm btn-ghost gap-2" (click)="retryOrders()" [disabled]="isRetrying">
-      @if (isRetrying) {
+    <div class="text-sm">{{ orderErrorMessage() }}</div>
+    <button class="btn btn-sm btn-ghost gap-2" (click)="retryOrders()" [disabled]="isRetrying()">
+      @if (isRetrying()) {
         <span class="loading loading-spinner loading-xs"></span>
       }
       Reintentar
@@ -37,373 +37,361 @@
   </div>
 }
 
-@if (dashboardStats$ | async; as stats) {
-  <!-- Estado Vacío Global -->
-  @if (deviceError && orderError && stats.totalDevices === 0 && stats.totalOrders === 0) {
-    <div
-      class="flex flex-col items-center justify-center py-16 px-4 text-center">
-      <h2 class="text-2xl font-bold mb-2 text-base-content">
-        No se pudieron cargar los datos
-      </h2>
-      <p class="text-base-content/60 mb-6 max-w-md">
-        Hubo un problema al conectar con el servidor.<br>
-        Por favor verifica tu conexión e intenta nuevamente.
-      </p>
-      <button class="btn btn-primary gap-2" (click)="retryLoadData()" [disabled]="isRetrying">
-        @if (isRetrying) {
-          <span class="loading loading-spinner loading-sm"></span>
-        }
-        {{ isRetrying ? 'Reintentando...' : 'Volver a intentar' }}
-      </button>
+@let stats = dashboardStats();
+@let alertsList = alerts();
+
+<!-- Estado Vacío Global -->
+@if (deviceError() && orderError() && stats.totalDevices === 0 && stats.totalOrders === 0) {
+  <div
+    class="flex flex-col items-center justify-center py-16 px-4 text-center">
+    <h2 class="text-2xl font-bold mb-2 text-base-content">
+      No se pudieron cargar los datos
+    </h2>
+    <p class="text-base-content/60 mb-6 max-w-md">
+      Hubo un problema al conectar con el servidor.<br>
+      Por favor verifica tu conexión e intenta nuevamente.
+    </p>
+    <button class="btn btn-primary gap-2" (click)="retryLoadData()" [disabled]="isRetrying()">
+      @if (isRetrying()) {
+        <span class="loading loading-spinner loading-sm"></span>
+      }
+      {{ isRetrying() ? 'Reintentando...' : 'Volver a intentar' }}
+    </button>
+  </div>
+}
+<!-- DASHBOARD PRINCIPAL -->
+@if (!(deviceError() && orderError() && stats.totalDevices === 0 && stats.totalOrders === 0)) {
+  <div
+    class="transition-opacity duration-300" [class.opacity-60]="isLoading()"
+    [class.pointer-events-none]="isLoading()">
+    <!-- HEADER -->
+    <div class="mb-6">
+      <h1 class="text-3xl font-bold">{{ getGreeting() }}</h1>
+      <p class="text-base-content/60 mt-2">Aquí está el resumen de tu sistema</p>
     </div>
-  }
-  <!-- DASHBOARD PRINCIPAL -->
-  @if (!(deviceError && orderError && stats.totalDevices === 0 && stats.totalOrders === 0)) {
-    <div
-      class="transition-opacity duration-300" [class.opacity-60]="loading$ | async"
-      [class.pointer-events-none]="loading$ | async">
-      <!-- HEADER -->
-      <div class="mb-6">
-        <h1 class="text-3xl font-bold">{{ getGreeting() }}</h1>
-        <p class="text-base-content/60 mt-2">Aquí está el resumen de tu sistema</p>
+    <!-- CARDS de DISPOSITIVOS (alertas/avisos de dispositivos) -->
+    @if (alertsList.length > 0) {
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
+        @for (alert of alertsList; track alert.title) {
+          <div class="alert shadow-lg" [ngClass]="getAlertClass(alert.type)">
+            <div>
+              <span class="text-2xl">{{ alert.icon }}</span>
+              <div>
+                <h3 class="font-bold">{{ alert.title }}</h3>
+                <div class="text-xs">{{ alert.message }}</div>
+              </div>
+            </div>
+            <div class="flex-none">
+              <div class="badge badge-lg">{{ alert.count }}</div>
+            </div>
+          </div>
+        }
       </div>
-      <!-- CARDS de DISPOSITIVOS (alertas/avisos de dispositivos) -->
-      @if (getAlerts(stats); as alerts) {
-        @if (alerts.length > 0) {
-          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
-            @for (alert of alerts; track alert) {
-              <div class="alert shadow-lg" [ngClass]="getAlertClass(alert.type)">
-                <div>
-                  <span class="text-2xl">{{ alert.icon }}</span>
-                  <div>
-                    <h3 class="font-bold">{{ alert.title }}</h3>
-                    <div class="text-xs">{{ alert.message }}</div>
-                  </div>
+    }
+    <!-- STATS: DISPOSITIVOS -->
+    @if (stats.totalDevices > 0) {
+      <div>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
+          <!-- Total Dispositivos -->
+          <div class="stats shadow-xl">
+            <div class="stat">
+              <div class="stat-figure text-primary">
+                <!-- Dispositivo (Tablet/Dispositivo Genérico) -->
+                <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round"
+                    d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
+                </svg>
+              </div>
+              <div class="stat-title">Total Dispositivos</div>
+              <div class="stat-value text-primary">{{ stats.totalDevices }}</div>
+              <div class="stat-desc">{{ stats.goodCondition }} en buen estado</div>
+            </div>
+          </div>
+          <!-- Estado Regular -->
+          <div class="stats shadow-xl">
+            <div class="stat">
+              <div class="stat-figure text-warning">
+                <!-- Exclamation Alert (Estado Regular/Advertencia) -->
+                <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round"
+                    d="M13 16h-1v-4h-1m0-4h.01M12 2a10 10 0 100 20 10 10 0 000-20z" />
+                </svg>
+              </div>
+              <div class="stat-title">Estado Regular</div>
+              <div class="stat-value text-warning">{{ stats.fair }}</div>
+              <div class="stat-desc">{{ getPercentage(stats.fair, stats.totalDevices) }}% del total</div>
+            </div>
+          </div>
+          <!-- Ocupados -->
+          <div class="stats shadow-xl">
+            <div class="stat">
+              <div class="stat-figure text-info">
+                <!-- User Group (Ocupados) -->
+                <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round"
+                    d="M17 20h5v-2a4 4 0 00-3-3.87M9 20H4v-2a4 4 0 013-3.87M16 7a4 4 0 11-8 0 4 4 0 018 0zm6 13a6 6 0 00-12 0v1h12v-1z" />
+                </svg>
+              </div>
+              <div class="stat-title">Ocupados</div>
+              <div class="stat-value text-info">{{ stats.occupied }}</div>
+              <div class="stat-desc">{{ getPercentage(stats.occupied, stats.totalDevices) }}% en uso</div>
+            </div>
+          </div>
+          <!-- Necesitan Reparación -->
+          <div class="stats shadow-xl">
+            <div class="stat">
+              <div class="stat-figure text-error">
+                <!-- Herramienta/Llave inglesa (Reparación) -->
+                <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round"
+                    d="M15.232 5.232l2.536-2.536a2 2 0 112.828 2.828l-2.536 2.536M9 13l3 3m0 0l6 6m-6-6l-6 6m6-6l-3-3" />
+                </svg>
+              </div>
+              <div class="stat-title">Necesitan Reparación</div>
+              <div class="stat-value text-error">{{ stats.needsRepair }}</div>
+              <div class="stat-desc">{{ getPercentage(stats.needsRepair, stats.totalDevices) }}% del total</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    }
+    <!-- Dispositivos por Marca -->
+    @if (devicesByBrand().length > 0) {
+      <div class="card bg-base-100 shadow-xl mb-6">
+        <div class="card-body">
+          <h2 class="card-title">📊 Top 5 Marcas</h2>
+          <div class="space-y-2">
+            @for (item of devicesByBrand(); track item.brand) {
+              <div class="flex items-center gap-4">
+                <div class="w-24 font-semibold">{{ item.brand }}</div>
+                <div class="flex-1">
+                  <progress class="progress progress-primary w-full" [value]="item.count"
+                  [max]="stats.totalDevices"></progress>
                 </div>
-                <div class="flex-none">
-                  <div class="badge badge-lg">{{ alert.count }}</div>
-                </div>
+                <div class="badge badge-lg badge-neutral">{{ item.count }}</div>
               </div>
             }
           </div>
-        }
-      }
-      <!-- STATS: DISPOSITIVOS -->
-      @if (stats.totalDevices > 0) {
-        <div>
-          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
-            <!-- Total Dispositivos -->
-            <div class="stats shadow-xl">
-              <div class="stat">
-                <div class="stat-figure text-primary">
-                  <!-- Dispositivo (Tablet/Dispositivo Genérico) -->
-                  <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round"
-                      d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
-                  </svg>
-                </div>
-                <div class="stat-title">Total Dispositivos</div>
-                <div class="stat-value text-primary">{{ stats.totalDevices }}</div>
-                <div class="stat-desc">{{ stats.goodCondition }} en buen estado</div>
+        </div>
+      </div>
+    }
+    <!-- Estado Vacío solo Devices -->
+    @if (deviceError() && stats.totalDevices === 0) {
+      <div class="card bg-base-100 shadow-xl mb-6">
+        <div class="card-body text-center py-12">
+          <h3 class="text-xl font-semibold mb-2">No se pudieron cargar los dispositivos</h3>
+          <p class="text-base-content/60 mb-4">{{ deviceErrorMessage() }}</p>
+          <button class="btn btn-primary btn-sm gap-2" (click)="retryDevices()" [disabled]="isRetrying()">
+            @if (isRetrying()) {
+              <span class="loading loading-spinner loading-xs"></span>
+            }
+            {{ isRetrying() ? 'Reintentando...' : 'Reintentar' }}
+          </button>
+        </div>
+      </div>
+    }
+    <!-- STATS: ÓRDENES -->
+    @if (stats.totalOrders > 0) {
+      <div>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6 mt-2">
+          <!-- Total Órdenes -->
+          <div class="stats shadow-xl">
+            <div class="stat">
+              <div class="stat-figure text-secondary">
+                <!-- Clipboard (órdenes, abstracto general) -->
+                <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round"
+                    d="M9 5h6a2 2 0 012 2v12a2 2 0 01-2 2H9a2 2 0 01-2-2V7a2 2 0 012-2z" />
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 3h6v2H9V3z" />
+                </svg>
               </div>
+              <div class="stat-title">Total Órdenes</div>
+              <div class="stat-value text-secondary">{{ stats.totalOrders }}</div>
+              <div class="stat-desc">{{ stats.activeOrders }} activas</div>
             </div>
-            <!-- Estado Regular -->
-            <div class="stats shadow-xl">
-              <div class="stat">
-                <div class="stat-figure text-warning">
-                  <!-- Exclamation Alert (Estado Regular/Advertencia) -->
-                  <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round"
-                      d="M13 16h-1v-4h-1m0-4h.01M12 2a10 10 0 100 20 10 10 0 000-20z" />
-                  </svg>
-                </div>
-                <div class="stat-title">Estado Regular</div>
-                <div class="stat-value text-warning">{{ stats.fair }}</div>
-                <div class="stat-desc">{{ getPercentage(stats.fair, stats.totalDevices) }}% del total</div>
+          </div>
+          <!-- Órdenes Creadas -->
+          <div class="stats shadow-xl">
+            <div class="stat">
+              <div class="stat-figure text-info">
+                <!-- Plus Circle (nuevas/creadas) -->
+                <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round"
+                    d="M12 9v6m3-3H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
               </div>
+              <div class="stat-title">Creadas</div>
+              <div class="stat-value text-info">{{ stats.createdOrders }}</div>
+              <div class="stat-desc">{{ getPercentage(stats.createdOrders, stats.totalOrders) }}% del total</div>
             </div>
-            <!-- Ocupados -->
-            <div class="stats shadow-xl">
-              <div class="stat">
-                <div class="stat-figure text-info">
-                  <!-- User Group (Ocupados) -->
-                  <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round"
-                      d="M17 20h5v-2a4 4 0 00-3-3.87M9 20H4v-2a4 4 0 013-3.87M16 7a4 4 0 11-8 0 4 4 0 018 0zm6 13a6 6 0 00-12 0v1h12v-1z" />
-                  </svg>
-                </div>
-                <div class="stat-title">Ocupados</div>
-                <div class="stat-value text-info">{{ stats.occupied }}</div>
-                <div class="stat-desc">{{ getPercentage(stats.occupied, stats.totalDevices) }}% en uso</div>
+          </div>
+          <!-- En Progreso -->
+          <div class="stats shadow-xl">
+            <div class="stat">
+              <div class="stat-figure text-warning">
+                <!-- Cog (en progreso) -->
+                <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round"
+                    d="M11 17a1 1 0 002 0m-8-6a1 1 0 010-2m16 2a1 1 0 010-2m-1.832-7.445A1 1 0 0016 5a1 1 0 00-1-1 1.001 1.001 0 01-.445-1.832M6.832 2.445A1 1 0 008 3a1 1 0 001 1 1.001 1.001 0 01.445 1.832M3 16.168A1 1 0 014 17a1 1 0 001 1 1.001 1.001 0 011.832.445M21 16.168A1 1 0 0020 17a1 1 0 00-1 1 1.001 1.001 0 00-.445 1.832" />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
               </div>
+              <div class="stat-title">En Progreso</div>
+              <div class="stat-value text-warning">{{ stats.inProcessOrders }}</div>
+              <div class="stat-desc">+ {{ stats.despatchedOrders }} despachadas</div>
             </div>
-            <!-- Necesitan Reparación -->
-            <div class="stats shadow-xl">
-              <div class="stat">
-                <div class="stat-figure text-error">
-                  <!-- Herramienta/Llave inglesa (Reparación) -->
-                  <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round"
-                      d="M15.232 5.232l2.536-2.536a2 2 0 112.828 2.828l-2.536 2.536M9 13l3 3m0 0l6 6m-6-6l-6 6m6-6l-3-3" />
-                  </svg>
-                </div>
-                <div class="stat-title">Necesitan Reparación</div>
-                <div class="stat-value text-error">{{ stats.needsRepair }}</div>
-                <div class="stat-desc">{{ getPercentage(stats.needsRepair, stats.totalDevices) }}% del total</div>
+          </div>
+          <!-- Finalizadas -->
+          <div class="stats shadow-xl">
+            <div class="stat">
+              <div class="stat-figure text-success">
+                <!-- Check Circle (finalizadas) -->
+                <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round"
+                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
               </div>
+              <div class="stat-title">Finalizadas</div>
+              <div class="stat-value text-success">{{ stats.finishedOrders }}</div>
+              <div class="stat-desc">{{ getPercentage(stats.finishedOrders, stats.totalOrders) }}% completadas</div>
             </div>
           </div>
         </div>
-      }
-      <!-- Dispositivos por Marca -->
-      @if (devicesByBrand.length > 0) {
-        <div class="card bg-base-100 shadow-xl mb-6">
-          <div class="card-body">
-            <h2 class="card-title">📊 Top 5 Marcas</h2>
-            <div class="space-y-2">
-              @for (item of devicesByBrand; track item) {
-                <div class="flex items-center gap-4">
-                  <div class="w-24 font-semibold">{{ item.brand }}</div>
-                  <div class="flex-1">
-                    <progress class="progress progress-primary w-full" [value]="item.count"
-                    [max]="stats.totalDevices"></progress>
-                  </div>
-                  <div class="badge badge-lg badge-neutral">{{ item.count }}</div>
-                </div>
-              }
-            </div>
-          </div>
+      </div>
+    }
+    <!-- Estado Vacío solo Órdenes -->
+    @if (orderError() && stats.totalOrders === 0) {
+      <div class="card bg-base-100 shadow-xl mt-6 mb-6">
+        <div class="card-body text-center py-12">
+          <h3 class="text-xl font-semibold mb-2">No se pudieron cargar las órdenes</h3>
+          <p class="text-base-content/60 mb-4">{{ orderErrorMessage() }}</p>
+          <button class="btn btn-primary btn-sm gap-2" (click)="retryOrders()" [disabled]="isRetrying()">
+            @if (isRetrying()) {
+              <span class="loading loading-spinner loading-xs"></span>
+            }
+            {{ isRetrying() ? 'Reintentando...' : 'Reintentar' }}
+          </button>
         </div>
-      }
-      <!-- Estado Vacío solo Devices -->
-      @if (deviceError && stats.totalDevices === 0) {
-        <div class="card bg-base-100 shadow-xl mb-6">
-          <div class="card-body text-center py-12">
-            <h3 class="text-xl font-semibold mb-2">No se pudieron cargar los dispositivos</h3>
-            <p class="text-base-content/60 mb-4">{{ deviceErrorMessage }}</p>
-            <button class="btn btn-primary btn-sm gap-2" (click)="retryDevices()" [disabled]="isRetrying">
-              @if (isRetrying) {
+      </div>
+    }
+    <!-- ÓRDENES RECIENTES: Detalle de la tabla -->
+    @if (recentOrders().length > 0) {
+      <div class="card bg-base-100 shadow-xl mt-6">
+        <div class="card-body">
+          <div class="flex justify-between items-center mb-4">
+            <h2 class="card-title">📋 Órdenes Recientes</h2>
+            <button class="btn btn-sm btn-ghost gap-2" (click)="refreshData()" [disabled]="isLoading()">
+              @if (isLoading()) {
                 <span class="loading loading-spinner loading-xs"></span>
               }
-              {{ isRetrying ? 'Reintentando...' : 'Reintentar' }}
+              <span class="hidden sm:inline">
+                {{ isLoading() ? 'Actualizando...' : 'Actualizar' }}
+              </span>
             </button>
           </div>
-        </div>
-      }
-      <!-- STATS: ÓRDENES -->
-      @if (stats.totalOrders > 0) {
-        <div>
-          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6 mt-2">
-            <!-- Total Órdenes -->
-            <div class="stats shadow-xl">
-              <div class="stat">
-                <div class="stat-figure text-secondary">
-                  <!-- Clipboard (órdenes, abstracto general) -->
-                  <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round"
-                      d="M9 5h6a2 2 0 012 2v12a2 2 0 01-2 2H9a2 2 0 01-2-2V7a2 2 0 012-2z" />
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 3h6v2H9V3z" />
-                  </svg>
-                </div>
-                <div class="stat-title">Total Órdenes</div>
-                <div class="stat-value text-secondary">{{ stats.totalOrders }}</div>
-                <div class="stat-desc">{{ stats.activeOrders }} activas</div>
-              </div>
-            </div>
-            <!-- Órdenes Creadas -->
-            <div class="stats shadow-xl">
-              <div class="stat">
-                <div class="stat-figure text-info">
-                  <!-- Plus Circle (nuevas/creadas) -->
-                  <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round"
-                      d="M12 9v6m3-3H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z" />
-                  </svg>
-                </div>
-                <div class="stat-title">Creadas</div>
-                <div class="stat-value text-info">{{ stats.createdOrders }}</div>
-                <div class="stat-desc">{{ getPercentage(stats.createdOrders, stats.totalOrders) }}% del total</div>
-              </div>
-            </div>
-            <!-- En Progreso -->
-            <div class="stats shadow-xl">
-              <div class="stat">
-                <div class="stat-figure text-warning">
-                  <!-- Cog (en progreso) -->
-                  <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round"
-                      d="M11 17a1 1 0 002 0m-8-6a1 1 0 010-2m16 2a1 1 0 010-2m-1.832-7.445A1 1 0 0016 5a1 1 0 00-1-1 1.001 1.001 0 01-.445-1.832M6.832 2.445A1 1 0 008 3a1 1 0 001 1 1.001 1.001 0 01.445 1.832M3 16.168A1 1 0 014 17a1 1 0 001 1 1.001 1.001 0 011.832.445M21 16.168A1 1 0 0020 17a1 1 0 00-1 1 1.001 1.001 0 00-.445 1.832" />
-                    <circle cx="12" cy="12" r="3" />
-                  </svg>
-                </div>
-                <div class="stat-title">En Progreso</div>
-                <div class="stat-value text-warning">{{ stats.inProcessOrders }}</div>
-                <div class="stat-desc">+ {{ stats.despatchedOrders }} despachadas</div>
-              </div>
-            </div>
-            <!-- Finalizadas -->
-            <div class="stats shadow-xl">
-              <div class="stat">
-                <div class="stat-figure text-success">
-                  <!-- Check Circle (finalizadas) -->
-                  <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round"
-                      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                  </svg>
-                </div>
-                <div class="stat-title">Finalizadas</div>
-                <div class="stat-value text-success">{{ stats.finishedOrders }}</div>
-                <div class="stat-desc">{{ getPercentage(stats.finishedOrders, stats.totalOrders) }}% completadas</div>
-              </div>
-            </div>
-          </div>
-        </div>
-      }
-      <!-- Estado Vacío solo Órdenes -->
-      @if (orderError && stats.totalOrders === 0) {
-        <div class="card bg-base-100 shadow-xl mt-6 mb-6">
-          <div class="card-body text-center py-12">
-            <h3 class="text-xl font-semibold mb-2">No se pudieron cargar las órdenes</h3>
-            <p class="text-base-content/60 mb-4">{{ orderErrorMessage }}</p>
-            <button class="btn btn-primary btn-sm gap-2" (click)="retryOrders()" [disabled]="isRetrying">
-              @if (isRetrying) {
-                <span class="loading loading-spinner loading-xs"></span>
-              }
-              {{ isRetrying ? 'Reintentando...' : 'Reintentar' }}
-            </button>
-          </div>
-        </div>
-      }
-      <!-- ÓRDENES RECIENTES: Detalle de la tabla -->
-      @if (recentOrders.length > 0) {
-        <div class="card bg-base-100 shadow-xl mt-6">
-          <div class="card-body">
-            <div class="flex justify-between items-center mb-4">
-              <h2 class="card-title">📋 Órdenes Recientes</h2>
-              <button class="btn btn-sm btn-ghost gap-2" (click)="refreshData()" [disabled]="loading$ | async">
-                @if (loading$ | async) {
-                  <span class="loading loading-spinner loading-xs"></span>
-                }
-                <span class="hidden sm:inline">
-                  {{ (loading$ | async) ? 'Actualizando...' : 'Actualizar' }}
-                </span>
-              </button>
-            </div>
-            <div class="overflow-x-auto">
-              <table class="table table-zebra">
-                <thead>
-                  <tr>
-                    <th>ID</th>
-                    <th>Descripción</th>
-                    <th>Dispositivos</th>
-                    <th>Asignado</th>
-                    <th>Estado</th>
-                    <th>Fecha</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  @for (order of recentOrders; track order) {
-                    <tr class="hover">
-                      <td>
-                        <div class="tooltip" [attr.data-tip]="order.id">
-                          <code class="text-xs">{{ getShortId(order.id) }}</code>
-                        </div>
-                      </td>
-                      <td>
-                        <div class="max-w-xs" [title]="order.description">
-                          {{ getTruncatedDescription(order.description, 40) }}
-                        </div>
-                      </td>
-                      <td>
-                        <div class="badge badge-neutral badge-lg">
-                          {{ getDeviceCount(order) }}
-                        </div>
-                      </td>
-                      <td>
-                        <div class="flex items-center gap-2">
-                          <span class="text-lg">{{ getAssigneeIcon(order.assigneeType) }}</span>
-                          <div class="text-sm">
-                            <div class="font-semibold">{{ order.assigneeType }}</div>
-                            <div class="tooltip" [attr.data-tip]="order.assigneeId">
-                              <code class="text-xs opacity-60">{{ getShortId(order.assigneeId) }}</code>
-                            </div>
+          <div class="overflow-x-auto">
+            <table class="table table-zebra">
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>Descripción</th>
+                  <th>Dispositivos</th>
+                  <th>Asignado</th>
+                  <th>Estado</th>
+                  <th>Fecha</th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (order of recentOrders(); track order.id) {
+                  <tr class="hover">
+                    <td>
+                      <div class="tooltip" [attr.data-tip]="order.id">
+                        <code class="text-xs">{{ getShortId(order.id) }}</code>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="max-w-xs" [title]="order.description">
+                        {{ getTruncatedDescription(order.description, 40) }}
+                      </div>
+                    </td>
+                    <td>
+                      <div class="badge badge-neutral badge-lg">
+                        {{ getDeviceCount(order) }}
+                      </div>
+                    </td>
+                    <td>
+                      <div class="flex items-center gap-2">
+                        <span class="text-lg">{{ getAssigneeIcon(order.assigneeType) }}</span>
+                        <div class="text-sm">
+                          <div class="font-semibold">{{ order.assigneeType }}</div>
+                          <div class="tooltip" [attr.data-tip]="order.assigneeId">
+                            <code class="text-xs opacity-60">{{ getShortId(order.assigneeId) }}</code>
                           </div>
                         </div>
-                      </td>
-                      <td>
-                        <span class="badge badge-lg" [ngClass]="getOrderStateClass(order.state)">
-                          {{ getOrderStateText(order.state) }}
-                        </span>
-                      </td>
-                      <td>
-                        <div class="text-sm">
-                          <div class="font-medium">{{ formatDate(order.createdAt) }}</div>
-                          <div class="text-xs opacity-60">{{ getRelativeTime(order.createdAt) }}</div>
-                        </div>
-                      </td>
-                    </tr>
-                  }
-                </tbody>
-              </table>
-            </div>
-            @if (recentOrders.length === 0) {
-              <div class="text-center py-8 text-base-content/60">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mx-auto mb-4 opacity-50" fill="none"
-                  viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                    d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                      </div>
+                    </td>
+                    <td>
+                      <span class="badge badge-lg" [ngClass]="getOrderStateClass(order.state)">
+                        {{ getOrderStateText(order.state) }}
+                      </span>
+                    </td>
+                    <td>
+                      <div class="text-sm">
+                        <div class="font-medium">{{ formatDate(order.createdAt) }}</div>
+                        <div class="text-xs opacity-60">{{ getRelativeTime(order.createdAt) }}</div>
+                      </div>
+                    </td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    }
+    <!-- Estadística Adicional de Órdenes: Dispositivos en Órdenes (AL FINAL) -->
+    @if (stats.totalOrders > 0) {
+      <div class="card bg-base-100 shadow-xl mt-6">
+        <div class="card-body">
+          <h2 class="card-title">📱 Dispositivos en Órdenes</h2>
+          <div class="stats stats-vertical lg:stats-horizontal shadow">
+            <div class="stat">
+              <div class="stat-figure text-primary">
+                <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round"
+                    d="M20 13V7a2 2 0 00-2-2H6a2 2 0 00-2 2v6m16 0V7a2 2 0 00-2-2m0 8v6a2 2 0 01-2 2H8a2 2 0 01-2-2v-6m16 0l-8 5-8-5" />
                 </svg>
-                <p class="text-lg font-semibold">No hay órdenes recientes</p>
-                <p class="text-sm">Las nuevas órdenes aparecerán aquí</p>
               </div>
-            }
-          </div>
-        </div>
-      }
-      <!-- Estadística Adicional de Órdenes: Dispositivos en Órdenes (AL FINAL) -->
-      @if (stats.totalOrders > 0) {
-        <div class="card bg-base-100 shadow-xl mt-6">
-          <div class="card-body">
-            <h2 class="card-title">📱 Dispositivos en Órdenes</h2>
-            <div class="stats stats-vertical lg:stats-horizontal shadow">
-              <div class="stat">
-                <div class="stat-figure text-primary">
-                  <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round"
-                      d="M20 13V7a2 2 0 00-2-2H6a2 2 0 00-2 2v6m16 0V7a2 2 0 00-2-2m0 8v6a2 2 0 01-2 2H8a2 2 0 01-2-2v-6m16 0l-8 5-8-5" />
-                  </svg>
-                </div>
-                <div class="stat-title">Total Dispositivos</div>
-                <div class="stat-value text-primary">{{ stats.totalDevicesInOrders }}</div>
-                <div class="stat-desc">En {{ stats.totalOrders }} órdenes</div>
+              <div class="stat-title">Total Dispositivos</div>
+              <div class="stat-value text-primary">{{ stats.totalDevicesInOrders }}</div>
+              <div class="stat-desc">En {{ stats.totalOrders }} órdenes</div>
+            </div>
+            <div class="stat">
+              <div class="stat-figure text-secondary">
+                <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round"
+                    d="M16 17a4 4 0 01-8 0M12 3v14m7 4H5m4-4H7a2 2 0 01-2-2v-5a2 2 0 012-2h2a2 2 0 012 2v5a2 2 0 01-2 2zm6 0h2a2 2 0 002-2v-5a2 2 0 00-2-2h-2a2 2 0 00-2 2v5a2 2 0 002 2z" />
+                </svg>
               </div>
-              <div class="stat">
-                <div class="stat-figure text-secondary">
-                  <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round"
-                      d="M16 17a4 4 0 01-8 0M12 3v14m7 4H5m4-4H7a2 2 0 01-2-2v-5a2 2 0 012-2h2a2 2 0 012 2v5a2 2 0 01-2 2zm6 0h2a2 2 0 002-2v-5a2 2 0 00-2-2h-2a2 2 0 00-2 2v5a2 2 0 002 2z" />
-                  </svg>
-                </div>
-                <div class="stat-title">Promedio por Orden</div>
-                <div class="stat-value text-secondary">{{ stats.averageItemsPerOrder }}</div>
-                <div class="stat-desc">Dispositivos por orden</div>
+              <div class="stat-title">Promedio por Orden</div>
+              <div class="stat-value text-secondary">{{ stats.averageItemsPerOrder }}</div>
+              <div class="stat-desc">Dispositivos por orden</div>
+            </div>
+            <div class="stat">
+              <div class="stat-figure text-accent">
+                <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round"
+                    d="M9 12l2 2l4-4m4 2A9 9 0 11 3 12a9 9 0 0118 0z" />
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h6" />
+                </svg>
               </div>
-              <div class="stat">
-                <div class="stat-figure text-accent">
-                  <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round"
-                      d="M9 12l2 2l4-4m4 2A9 9 0 11 3 12a9 9 0 0118 0z" />
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h6" />
-                  </svg>
-                </div>
-                <div class="stat-title">Órdenes Activas</div>
-                <div class="stat-value text-accent">{{ stats.activeOrders }}</div>
-                <div class="stat-desc">{{ getPercentage(stats.activeOrders, stats.totalOrders) }}% del total</div>
-              </div>
+              <div class="stat-title">Órdenes Activas</div>
+              <div class="stat-value text-accent">{{ stats.activeOrders }}</div>
+              <div class="stat-desc">{{ getPercentage(stats.activeOrders, stats.totalOrders) }}% del total</div>
             </div>
           </div>
         </div>
-      }
-    </div>
-  }
+      </div>
+    }
+  </div>
 }

--- a/src/app/modules/private/dashboard/dashboard.component.ts
+++ b/src/app/modules/private/dashboard/dashboard.component.ts
@@ -1,528 +1,211 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Order, OrderStateLabels, OrderStates } from '../orders/models/Orders';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { Order, OrderStateLabels } from '../orders/models/Orders';
 import { DevicesService } from '../devices/services/devices.service';
 import { AuthService } from '../../../core/services/auth.service';
 import { User } from '../../public/auth/models/user.model';
-import { forkJoin } from 'rxjs/internal/observable/forkJoin';
-import { catchError, Observable, of, map } from 'rxjs';
+import { forkJoin, catchError, of, finalize } from 'rxjs';
 import { Device, DeviceStatus } from '../devices/models/device.model';
-import { Subject } from 'rxjs/internal/Subject';
-import { OrdersService } from '../orders/services/orders.service';
+import { OrdersStore } from '../orders/store/orders.store';
 import { LoadingService } from '../../../core/services/loading.service';
-import { Alerta, DashboardStatsType } from './models/DashboardStats';
+import { Alerta, DashboardStatsType, DEFAULT_STATS } from './models/DashboardStats';
+
 
 /**
- * Componente de Dashboard
- * Muestra estadísticas y datos relevantes para el usuario, como el número total de dispositivos y las órdenes recientes
- *
+ * Componente principal del dashboard que muestra estadísticas clave, alertas, y resúmenes de dispositivos y órdenes recientes. Gestiona la carga de datos, manejo de errores y proporciona funcionalidades para refrescar la información.
+ * @since 1.0.0
  * @author Bunnystring
- * @since 2026-02-06
  */
 @Component({
   selector: 'app-dashboard',
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [CommonModule],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.css',
 })
-export class DashboardComponent implements OnInit, OnDestroy {
-  // Datos del usuario autenticado
-  user: User | null = null;
+export class DashboardComponent implements OnInit {
+  private readonly ordersStore = inject(OrdersStore);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly devicesService = inject(DevicesService);
+  private readonly authService = inject(AuthService);
 
-  get loading$(): Observable<boolean> {
-    return this.loadingService.loading$;
-  }
+  readonly isLoading = toSignal(inject(LoadingService).loading$, { initialValue: false });
 
-  // Observables para estadísticas y datos del dashboard
-  dashboardStats$: Observable<{
-    totalDevices: number;
-    goodCondition: number;
-    occupied: number;
-    needsRepair: number;
-    fair: number;
-    totalOrders: number;
-    activeOrders: number;
-    createdOrders: number;
-    inProcessOrders: number;
-    despatchedOrders: number;
-    finishedOrders: number;
-    totalDevicesInOrders: number;
-    averageItemsPerOrder: number;
-  }> = of({
-    totalDevices: 0,
-    goodCondition: 0,
-    occupied: 0,
-    needsRepair: 0,
-    fair: 0,
-    totalOrders: 0,
-    activeOrders: 0,
-    createdOrders: 0,
-    inProcessOrders: 0,
-    despatchedOrders: 0,
-    finishedOrders: 0,
-    totalDevicesInOrders: 0,
-    averageItemsPerOrder: 0,
-  });
+  readonly user = signal<User | null>(null);
 
-  // Datos para mostrar en el dashboard
-  recentDevices: Device[] = [];
-  recentOrders: Order[] = [];
-  devicesByBrand: { brand: string; count: number }[] = [];
+  private readonly _stats = signal<DashboardStatsType>(DEFAULT_STATS);
+  readonly dashboardStats = this._stats.asReadonly();
 
-  // Referencia a orderStates para usar en el template
-  orderStates = OrderStates;
+  readonly recentDevices = signal<Device[]>([]);
+  readonly recentOrders = signal<Order[]>([]);
+  readonly devicesByBrand = signal<{ brand: string; count: number }[]>([]);
 
-  // Manejo de errores
-  deviceError = false;
-  deviceErrorMessage = '';
-  orderError = false;
-  orderErrorMessage = '';
-  isRetrying = false;
+  readonly deviceError = signal(false);
+  readonly deviceErrorMessage = signal('');
+  readonly orderError = signal(false);
+  readonly orderErrorMessage = signal('');
+  readonly isRetrying = signal(false);
 
-  // Computed property para saber si hay algún error
-  get hasAnyError(): boolean {
-    return this.deviceError || this.orderError;
-  }
+  readonly hasAnyError = computed(() => this.deviceError() || this.orderError());
+  readonly alerts = computed(() => this.buildAlerts(this._stats()));
 
-  // Subject para manejar desuscripciones y evitar fugas de memoria
-  destroy$: Subject<void> = new Subject<void>();
-
-  constructor(
-    private devicesService: DevicesService,
-    private authService: AuthService,
-    private ordersService: OrdersService,
-    private loadingService: LoadingService,
-  ) {}
-
-  /**
-   * Inicializa el componente cargando los datos necesarios para mostrar en el dashboard, como los dispositivos y las órdenes, y calculando las estadísticas correspondientes
-   *
-   * @return void
-   */
-  ngOnInit() {
-    this.initParams();
-    this.loadUser();
-  }
-
-  /**
-   * Limpia las suscripciones para evitar fugas de memoria cuando el componente es destruido
-   *
-   * @return void
-   */
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
-
-  /**
-   * Inicializa los parámetros del dashboard
-   */
-  initParams() {
+  ngOnInit(): void {
+    this.user.set(this.authService.getCurrentUser());
     this.loadDashboardData();
   }
 
-  /**
-   * Carga los datos del dashboard, incluyendo dispositivos y órdenes,
-   * y maneja los errores de forma individual para cada recurso, permitiendo mostrar
-   * datos previos si una de las cargas falla, y actualizando las estadísticas y alertas en consecuencia
-   * @returns void
-   */
   private loadDashboardData(): void {
-    this.deviceError = false;
-    this.deviceErrorMessage = '';
-    this.orderError = false;
-    this.orderErrorMessage = '';
-    this.dashboardStats$ = forkJoin({
+    this.deviceError.set(false);
+    this.deviceErrorMessage.set('');
+    this.orderError.set(false);
+    this.orderErrorMessage.set('');
+
+    forkJoin({
       devices: this.devicesService.getAllDevices().pipe(
         catchError((error) => {
           console.error('Error al cargar dispositivos:', error);
-          this.deviceError = true;
-          this.deviceErrorMessage =
-            error.message || 'Error al cargar dispositivos';
+          this.deviceError.set(true);
+          this.deviceErrorMessage.set(error.message || 'Error al cargar dispositivos');
           return of([] as Device[]);
         }),
       ),
-      orders: this.ordersService.getAllOrders().pipe(
+      orders: this.ordersStore.loadOrders().pipe(
         catchError((error) => {
           console.error('Error al cargar órdenes:', error);
-          this.orderError = true;
-          this.orderErrorMessage = error.message || 'Error al cargar órdenes';
+          this.orderError.set(true);
+          this.orderErrorMessage.set(error.message || 'Error al cargar órdenes');
           return of([] as Order[]);
         }),
       ),
     }).pipe(
-      map(({ devices, orders }) => {
-        this.recentOrders = this.getRecentOrders(orders, 5);
-        this.devicesByBrand = this.getDevicesByBrand(devices);
-        const totalDevices = devices.length;
-        const goodCondition = devices.filter(
-          (d) => d.status === DeviceStatus.GOOD_CONDITION,
-        ).length;
-        const occupied = devices.filter(
-          (d) => d.status === DeviceStatus.OCCUPIED,
-        ).length;
-        const needsRepair = devices.filter(
-          (d) => d.status === DeviceStatus.NEEDS_REPAIR,
-        ).length;
-        const fair = devices.filter(
-          (d) => d.status === DeviceStatus.FAIR,
-        ).length;
-
-        const totalOrders = orders.length;
-        const createdOrders = orders.filter(
-          (o) => o.state === 'CREATED',
-        ).length;
-        const inProcessOrders = orders.filter(
-          (o) => o.state === 'IN_PROCESS',
-        ).length;
-        const despatchedOrders = orders.filter(
-          (o) => o.state === 'DISPATCHED',
-        ).length;
-        const finishedOrders = orders.filter(
-          (o) => o.state === 'FINISHED',
-        ).length;
-        const activeOrders = createdOrders + inProcessOrders + despatchedOrders;
-
-        const totalDevicesInOrders = orders.reduce(
-          (sum, order) => sum + (order.items?.length || 0),
-          0,
-        );
-        const averageItemsPerOrder =
-          orders.length > 0
-            ? Math.round((totalDevicesInOrders / orders.length) * 10) / 10
-            : 0;
-
-        return {
-          totalDevices,
-          goodCondition,
-          occupied,
-          needsRepair,
-          fair,
-          totalOrders,
-          activeOrders,
-          createdOrders,
-          inProcessOrders,
-          despatchedOrders,
-          finishedOrders,
-          totalDevicesInOrders,
-          averageItemsPerOrder,
-        };
-      }),
-    );
+      finalize(() => this.isRetrying.set(false)),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe(({ devices, orders }) => {
+      this.recentDevices.set(this.getRecentDevices(devices, 5));
+      this.recentOrders.set(this.getRecentOrders(orders, 5));
+      this.devicesByBrand.set(this.getDevicesByBrand(devices));
+      this._stats.set(this.computeStats(devices, orders));
+    });
   }
 
-  /**
-   * Extrae un mensaje de error legible para el usuario basado en el error recibido
-   * y el recurso que se intentaba cargar, manejando casos comunes como falta de conexión,
-   * recursos no encontrados o errores del servidor
-   * @param error
-   * @param resource
-   * @returns
-   */
-  private extractErrorMessage(error: any, resource: string): string {
-    if (error.message) {
-      return error.message;
-    }
-
-    if (error.status === 0) {
-      return `No se pudo conectar al servidor de ${resource}`;
-    }
-
-    if (error.status === 404) {
-      return `Servicio de ${resource} no encontrado`;
-    }
-
-    if (error.status >= 500) {
-      return `Error del servidor de ${resource}`;
-    }
-
-    return `Error al cargar ${resource}`;
-  }
-
-  /**
-   * Reintentar cargar los datos del dashboard,
-   * reseteando los estados de error y mostrando el indicador de carga mientras se realiza la nueva solicitud,
-   * permitiendo al usuario intentar recuperar los datos después de un error sin necesidad de recargar toda la página
-   * @returns void
-   */
   retryLoadData(): void {
-    this.isRetrying = true;
+    this.isRetrying.set(true);
     this.loadDashboardData();
   }
 
-  /**
-   * Reintentar solo dispositivos en caso de error,
-   * permitiendo al usuario intentar recuperar los datos de dispositivos sin afectar la sección de órdenes,
-   * y viceversa
-   * @returns void
-   */
   retryDevices(): void {
-    this.isRetrying = true;
-    this.deviceError = false;
-    this.deviceErrorMessage = '';
+    this.isRetrying.set(true);
+    this.deviceError.set(false);
+    this.deviceErrorMessage.set('');
 
     this.devicesService
       .getAllDevices()
       .pipe(
         catchError((error) => {
-          console.error(' Error al cargar dispositivos:', error);
-          this.deviceError = true;
-          this.deviceErrorMessage = this.extractErrorMessage(
-            error,
-            'dispositivos',
-          );
-          this.isRetrying = false;
+          console.error('Error al cargar dispositivos:', error);
+          this.deviceError.set(true);
+          this.deviceErrorMessage.set(this.extractErrorMessage(error, 'dispositivos'));
+          this.isRetrying.set(false);
           return of([] as Device[]);
         }),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((devices) => {
         if (devices.length > 0) {
-          this.recentDevices = this.getRecentDevices(devices, 5);
-          this.devicesByBrand = this.getDevicesByBrand(devices);
-        } else {
-          // Si no hay datos y no hay error, resetear
-          if (!this.deviceError) {
-            this.recentDevices = [];
-            this.devicesByBrand = [];
-          }
+          this.recentDevices.set(this.getRecentDevices(devices, 5));
+          this.devicesByBrand.set(this.getDevicesByBrand(devices));
+        } else if (!this.deviceError()) {
+          this.recentDevices.set([]);
+          this.devicesByBrand.set([]);
         }
-        this.isRetrying = false;
+        this.isRetrying.set(false);
       });
   }
 
-  /**
-   * Reintentar solo órdenes en caso de error,
-   * permitiendo al usuario intentar recuperar los datos de órdenes sin afectar la sección de dispositivos,
-   * y viceversa
-   * @returns void
-   */
   retryOrders(): void {
-    this.isRetrying = true;
-    this.orderError = false;
-    this.orderErrorMessage = '';
+    this.isRetrying.set(true);
+    this.orderError.set(false);
+    this.orderErrorMessage.set('');
 
-    this.ordersService
-      .getAllOrders()
+    this.ordersStore
+      .loadOrders()
       .pipe(
         catchError((error) => {
-          console.error(' Error al cargar órdenes:', error);
-          this.orderError = true;
-          this.orderErrorMessage = this.extractErrorMessage(error, 'órdenes');
-          this.isRetrying = false;
+          console.error('Error al cargar órdenes:', error);
+          this.orderError.set(true);
+          this.orderErrorMessage.set(this.extractErrorMessage(error, 'órdenes'));
+          this.isRetrying.set(false);
           return of([] as Order[]);
         }),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((orders) => {
         if (orders.length > 0) {
-          this.recentOrders = this.getRecentOrders(orders, 5);
-        } else {
-          if (!this.orderError) {
-            this.recentOrders = [];
-          }
+          this.recentOrders.set(this.getRecentOrders(orders, 5));
+        } else if (!this.orderError()) {
+          this.recentOrders.set([]);
         }
-        this.isRetrying = false;
+        this.isRetrying.set(false);
       });
   }
 
-  /**
-   * Obtener dispositivos recientes basados en la fecha de creación
-   * @param devices Lista completa de dispositivos
-   */
-  private getRecentDevices(devices: Device[], limit: number): Device[] {
-    return devices
-      .sort(
-        (a, b) =>
-          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-      )
-      .slice(0, limit);
+  refreshData(): void {
+    this.loadDashboardData();
   }
 
-  /**
-   * Obtener conteo de dispositivos por marca
-   * @return Array de objetos con marca y conteo, ordenados por conteo descendente
-   */
-  private getDevicesByBrand(
-    devices: Device[],
-  ): { brand: string; count: number }[] {
-    const brandCount: { [key: string]: number } = {};
-
-    devices.forEach((device) => {
-      const brand = device.brand.toUpperCase();
-      brandCount[brand] = (brandCount[brand] || 0) + 1;
-    });
-
-    return Object.entries(brandCount)
-      .map(([brand, count]) => ({ brand, count }))
-      .sort((a, b) => b.count - a.count)
-      .slice(0, 5); // Top 5 marcas
-  }
-
-  /**
-   * Carga datos del usuario autenticado para mostrar en el dashboard
-   *
-   * @return void
-   */
-  private loadUser(): void {
-    this.user = this.authService.getCurrentUser();
-  }
-
-  /**
-   * Obtener primer nombre del usuario
-   * @returns Primer nombre o string vacío
-   */
   getFirstName(): string {
-    if (!this.user?.name) {
-      return '';
-    }
-    return this.user.name.split(' ')[0];
+    const name = this.user()?.name;
+    return name ? name.split(' ')[0] : '';
   }
 
-  /**
-   * Obtener saludo personalizado
-   * @returns Mensaje de bienvenida
-   */
   getGreeting(): string {
     const firstName = this.getFirstName();
     return firstName ? `👋 ¡Bienvenido, ${firstName}!` : '👋 ¡Bienvenido!';
   }
 
-  /**
-   * Calcular porcentaje para gráficos de progreso
-   * @param value Valor actual
-   * @param total Valor total
-   * @returns Porcentaje calculado
-   */
   getPercentage(value: number, total: number): number {
     return total > 0 ? Math.round((value / total) * 100) : 0;
   }
 
-  /**
-   * Refrescar datos del dashboard después de una acción que pueda haber cambiado el estado de los dispositivos u órdenes
-   * @returns
-   * void
-   */
-  refreshData(): void {
-    this.loadDashboardData();
+  getAlertClass(type: string): string {
+    const alertMap: Record<string, string> = {
+      warning: 'alert-warning', info: 'alert-info',
+      primary: 'alert-primary', success: 'alert-success', error: 'alert-error',
+    };
+    return alertMap[type] || 'alert-info';
   }
 
-  /**
-   * Obtener órdenes recientes basadas en la fecha de creación
-   * @param orders Lista completa de órdenes
-   * @param limit Cantidad de órdenes a retornar
-   * @return Array de órdenes recientes
-   */
-  private getRecentOrders(orders: Order[], limit: number): Order[] {
-    return orders
-      .sort(
-        (a, b) =>
-          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-      )
-      .slice(0, limit);
-  }
-
-  /**
-   * Actualizar mensajes y conteos de alertas basados en las estadísticas actuales
-   * @returns void
-   */
-  getAlerts(stats: DashboardStatsType): Alerta[] {
-    return [
-      {
-        type: 'warning',
-        icon: '⚠️',
-        title: 'Dispositivos que necesitan reparación',
-        message: `${stats.needsRepair} dispositivo${stats.needsRepair !== 1 ? 's' : ''} requiere${stats.needsRepair === 1 ? '' : 'n'} atención`,
-        count: stats.needsRepair,
-      },
-      {
-        type: 'info',
-        icon: '📋',
-        title: 'Órdenes creadas',
-        message: `${stats.createdOrders} orden${stats.createdOrders !== 1 ? 'es' : ''} esperando inicio`,
-        count: stats.createdOrders,
-      },
-      {
-        type: 'primary',
-        icon: '🔄',
-        title: 'Órdenes en progreso',
-        message: `${stats.inProcessOrders} orden${stats.inProcessOrders !== 1 ? 'es' : ''} en proceso`,
-        count: stats.inProcessOrders,
-      },
-      {
-        type: 'success',
-        icon: '✅',
-        title: 'Órdenes finalizadas',
-        message: `${stats.finishedOrders} orden${stats.finishedOrders !== 1 ? 'es' : ''} completadas`,
-        count: stats.finishedOrders,
-      },
-    ];
-  }
-
-  /**
-   * Obtener clase CSS para el estado de la orden
-   * @param state Estado de la orden
-   * @returns Clase CSS correspondiente
-   */
   getOrderStateClass(state: string): string {
     const stateMap: Record<string, string> = {
-      CREATED: 'badge-info',
-      IN_PROCESS: 'badge-warning',
-      DESPATCHED: 'badge-primary',
-      FINISHED: 'badge-success',
+      CREATED: 'badge-info', IN_PROCESS: 'badge-warning',
+      DESPATCHED: 'badge-primary', FINISHED: 'badge-success',
       CREATED_WITH_ERRORS: 'badge-error',
     };
     return stateMap[state] || 'badge-ghost';
   }
 
-  /**
-   * Obtener texto para estado de orden
-   * @param state Estado de la orden
-   * @returns Texto legible del estado
-   */
   getOrderStateText(state: string): string {
-    const orderState =
-      OrderStateLabels[state as keyof typeof OrderStateLabels] || state;
-    return orderState;
+    return OrderStateLabels[state as keyof typeof OrderStateLabels] || state;
   }
 
-  /**
-   * Obtener clase CSS para tipo de alerta
-   * @param type Tipo de alerta
-   * @returns Clase CSS correspondiente
-   */
-  getAlertClass(type: string): string {
-    const alertMap: Record<string, string> = {
-      warning: 'alert-warning',
-      info: 'alert-info',
-      primary: 'alert-primary',
-      success: 'alert-success',
-      error: 'alert-error',
-    };
-    return alertMap[type] || 'alert-info';
-  }
-
-  /**
-   * Formatear fecha
-   * @param date Fecha en formato string
-   * @returns Fecha formateada
-   */
   formatDate(date: string): string {
     return new Date(date).toLocaleDateString('es-CO', {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric',
+      day: '2-digit', month: '2-digit', year: 'numeric',
     });
   }
 
-  /**
-   * Formatear fecha relativa (hace X tiempo)
-   * @param date Fecha en formato string
-   * @returns Texto con tiempo relativo
-   */
   getRelativeTime(date: string): string {
-    const now = new Date();
-    const orderDate = new Date(date);
-    const diffMs = now.getTime() - orderDate.getTime();
+    const diffMs = Date.now() - new Date(date).getTime();
     const diffMins = Math.floor(diffMs / 60000);
     const diffHours = Math.floor(diffMs / 3600000);
     const diffDays = Math.floor(diffMs / 86400000);
@@ -532,64 +215,110 @@ export class DashboardComponent implements OnInit, OnDestroy {
     if (diffHours < 24) return `Hace ${diffHours}h`;
     if (diffDays === 1) return 'Ayer';
     if (diffDays < 7) return `Hace ${diffDays} días`;
-
     return this.formatDate(date);
   }
 
-  /**
-   * Obtener descripción truncada
-   * @param description Descripción completa
-   * @param maxLength Longitud máxima
-   * @returns Descripción truncada
-   */
-  getTruncatedDescription(description: string, maxLength: number = 50): string {
-    if (description.length <= maxLength) return description;
-    return description.substring(0, maxLength) + '...';
+  getTruncatedDescription(description: string, maxLength = 50): string {
+    return description.length <= maxLength ? description : description.substring(0, maxLength) + '...';
   }
 
-  /**
-   * Obtener cantidad de dispositivos en una orden
-   * @param order Orden
-   * @returns Cantidad de dispositivos
-   */
   getDeviceCount(order: Order): number {
     return order.items.length;
   }
 
-  /**
-   * Obtener color para el estado del dispositivo original
-   * @param state Estado del dispositivo
-   * @returns Clase CSS de color
-   */
-  getDeviceStateColor(state: string): string {
-    const colorMap: Record<string, string> = {
-      GOOD_CONDITION: 'badge-success',
-      FAIR: 'badge-warning',
-      NEEDS_REPAIR: 'badge-error',
-      OCCUPIED: 'badge-info',
-    };
-    return colorMap[state] || 'badge-ghost';
-  }
-
-  /**
-   * Obtener ícono para tipo de asignado
-   * @param type Tipo de asignado
-   * @returns Emoji correspondiente
-   */
   getAssigneeIcon(type: string): string {
-    const iconMap: Record<string, string> = {
-      GROUP: '👥',
-      INDIVIDUAL: '👤',
-    };
+    const iconMap: Record<string, string> = { GROUP: '👥', INDIVIDUAL: '👤' };
     return iconMap[type] || '📋';
   }
 
-  /**
-   * Formatear UUID corto (primeros 8 caracteres)
-   * @param id UUID completo
-   * @returns UUID truncado
-   */
   getShortId(id: string): string {
     return id.substring(0, 8);
+  }
+
+  private computeStats(devices: Device[], orders: Order[]): DashboardStatsType {
+    const totalDevices = devices.length;
+    const goodCondition = devices.filter(d => d.status === DeviceStatus.GOOD_CONDITION).length;
+    const occupied = devices.filter(d => d.status === DeviceStatus.OCCUPIED).length;
+    const needsRepair = devices.filter(d => d.status === DeviceStatus.NEEDS_REPAIR).length;
+    const fair = devices.filter(d => d.status === DeviceStatus.FAIR).length;
+
+    const totalOrders = orders.length;
+    const createdOrders = orders.filter(o => o.state === 'CREATED').length;
+    const inProcessOrders = orders.filter(o => o.state === 'IN_PROCESS').length;
+    const despatchedOrders = orders.filter(o => o.state === 'DISPATCHED').length;
+    const finishedOrders = orders.filter(o => o.state === 'FINISHED').length;
+    const activeOrders = createdOrders + inProcessOrders + despatchedOrders;
+
+    const totalDevicesInOrders = orders.reduce((sum, o) => sum + (o.items?.length || 0), 0);
+    const averageItemsPerOrder = totalOrders > 0
+      ? Math.round((totalDevicesInOrders / totalOrders) * 10) / 10
+      : 0;
+
+    return {
+      totalDevices, goodCondition, occupied, needsRepair, fair,
+      totalOrders, activeOrders, createdOrders, inProcessOrders,
+      despatchedOrders, finishedOrders, totalDevicesInOrders, averageItemsPerOrder,
+    };
+  }
+
+  private buildAlerts(stats: DashboardStatsType): Alerta[] {
+    return [
+      {
+        type: 'warning', icon: '⚠️',
+        title: 'Dispositivos que necesitan reparación',
+        message: `${stats.needsRepair} dispositivo${stats.needsRepair !== 1 ? 's' : ''} requiere${stats.needsRepair === 1 ? '' : 'n'} atención`,
+        count: stats.needsRepair,
+      },
+      {
+        type: 'info', icon: '📋',
+        title: 'Órdenes creadas',
+        message: `${stats.createdOrders} orden${stats.createdOrders !== 1 ? 'es' : ''} esperando inicio`,
+        count: stats.createdOrders,
+      },
+      {
+        type: 'primary', icon: '🔄',
+        title: 'Órdenes en progreso',
+        message: `${stats.inProcessOrders} orden${stats.inProcessOrders !== 1 ? 'es' : ''} en proceso`,
+        count: stats.inProcessOrders,
+      },
+      {
+        type: 'success', icon: '✅',
+        title: 'Órdenes finalizadas',
+        message: `${stats.finishedOrders} orden${stats.finishedOrders !== 1 ? 'es' : ''} completadas`,
+        count: stats.finishedOrders,
+      },
+    ];
+  }
+
+  private extractErrorMessage(error: any, resource: string): string {
+    if (error.message) return error.message;
+    if (error.status === 0) return `No se pudo conectar al servidor de ${resource}`;
+    if (error.status === 404) return `Servicio de ${resource} no encontrado`;
+    if (error.status >= 500) return `Error del servidor de ${resource}`;
+    return `Error al cargar ${resource}`;
+  }
+
+  private getRecentDevices(devices: Device[], limit: number): Device[] {
+    return [...devices]
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+      .slice(0, limit);
+  }
+
+  private getDevicesByBrand(devices: Device[]): { brand: string; count: number }[] {
+    const brandCount: Record<string, number> = {};
+    devices.forEach(device => {
+      const brand = device.brand.toUpperCase();
+      brandCount[brand] = (brandCount[brand] || 0) + 1;
+    });
+    return Object.entries(brandCount)
+      .map(([brand, count]) => ({ brand, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 5);
+  }
+
+  private getRecentOrders(orders: Order[], limit: number): Order[] {
+    return [...orders]
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+      .slice(0, limit);
   }
 }

--- a/src/app/modules/private/dashboard/models/DashboardStats.ts
+++ b/src/app/modules/private/dashboard/models/DashboardStats.ts
@@ -72,3 +72,14 @@ export type DashboardStatsType = {
   totalDevicesInOrders: number;
   averageItemsPerOrder: number;
 };
+
+/**
+ * Constante que representa las estadísticas por defecto del dashboard, con todos los valores inicializados a cero.
+ * @since 2026-02-05
+ * @author Bunnystring
+ */
+export const DEFAULT_STATS: DashboardStatsType = {
+  totalDevices: 0, goodCondition: 0, occupied: 0, needsRepair: 0, fair: 0,
+  totalOrders: 0, activeOrders: 0, createdOrders: 0, inProcessOrders: 0,
+  despatchedOrders: 0, finishedOrders: 0, totalDevicesInOrders: 0, averageItemsPerOrder: 0,
+};

--- a/src/app/modules/private/devices/modals/device-bulk-upload-modal/device-bulk-upload-modal.component.spec.ts
+++ b/src/app/modules/private/devices/modals/device-bulk-upload-modal/device-bulk-upload-modal.component.spec.ts
@@ -1,28 +1,15 @@
-/* tslint:disable:no-unused-variable */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
-
+import { TestBed } from '@angular/core/testing';
 import { DeviceBulkUploadModalComponent } from './device-bulk-upload-modal.component';
 
 describe('DeviceBulkUploadModalComponent', () => {
-  let component: DeviceBulkUploadModalComponent;
-  let fixture: ComponentFixture<DeviceBulkUploadModalComponent>;
-
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ DeviceBulkUploadModalComponent ]
-    })
-    .compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(DeviceBulkUploadModalComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DeviceBulkUploadModalComponent],
+    }).compileComponents();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    const fixture = TestBed.createComponent(DeviceBulkUploadModalComponent);
+    expect(fixture.componentInstance).toBeTruthy();
   });
 });

--- a/src/app/modules/private/devices/modals/device-create-edit-modal/device-create-edit-modal.component.spec.ts
+++ b/src/app/modules/private/devices/modals/device-create-edit-modal/device-create-edit-modal.component.spec.ts
@@ -1,28 +1,15 @@
-/* tslint:disable:no-unused-variable */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
-
+import { TestBed } from '@angular/core/testing';
 import { DeviceCreateEditModalComponent } from './device-create-edit-modal.component';
 
 describe('DeviceCreateEditModalComponent', () => {
-  let component: DeviceCreateEditModalComponent;
-  let fixture: ComponentFixture<DeviceCreateEditModalComponent>;
-
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ DeviceCreateEditModalComponent ]
-    })
-    .compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(DeviceCreateEditModalComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DeviceCreateEditModalComponent],
+    }).compileComponents();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    const fixture = TestBed.createComponent(DeviceCreateEditModalComponent);
+    expect(fixture.componentInstance).toBeTruthy();
   });
 });

--- a/src/app/modules/private/devices/modals/device-delete-modal/device-delete-modal.component.spec.ts
+++ b/src/app/modules/private/devices/modals/device-delete-modal/device-delete-modal.component.spec.ts
@@ -1,28 +1,15 @@
-/* tslint:disable:no-unused-variable */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
-
+import { TestBed } from '@angular/core/testing';
 import { DeviceDeleteModalComponent } from './device-delete-modal.component';
 
 describe('DeviceDeleteModalComponent', () => {
-  let component: DeviceDeleteModalComponent;
-  let fixture: ComponentFixture<DeviceDeleteModalComponent>;
-
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ DeviceDeleteModalComponent ]
-    })
-    .compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(DeviceDeleteModalComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DeviceDeleteModalComponent],
+    }).compileComponents();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    const fixture = TestBed.createComponent(DeviceDeleteModalComponent);
+    expect(fixture.componentInstance).toBeTruthy();
   });
 });

--- a/src/app/modules/private/devices/pages/devices-detail/devices-detail.component.spec.ts
+++ b/src/app/modules/private/devices/pages/devices-detail/devices-detail.component.spec.ts
@@ -1,28 +1,23 @@
-/* tslint:disable:no-unused-variable */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
-
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { DevicesDetailComponent } from './devices-detail.component';
 
 describe('DevicesDetailComponent', () => {
-  let component: DevicesDetailComponent;
-  let fixture: ComponentFixture<DevicesDetailComponent>;
-
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ DevicesDetailComponent ]
-    })
-    .compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(DevicesDetailComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DevicesDetailComponent],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    const fixture = TestBed.createComponent(DevicesDetailComponent);
+    expect(fixture.componentInstance).toBeTruthy();
   });
 });

--- a/src/app/modules/private/devices/pages/devices/devices.component.spec.ts
+++ b/src/app/modules/private/devices/pages/devices/devices.component.spec.ts
@@ -1,4 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { DevicesComponent } from './devices.component';
 
@@ -8,9 +11,13 @@ describe('DevicesComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [DevicesComponent]
-    })
-    .compileComponents();
+      imports: [DevicesComponent],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(DevicesComponent);
     component = fixture.componentInstance;

--- a/src/app/modules/private/employees/pages/employees-detail/employees-detail.component.spec.ts
+++ b/src/app/modules/private/employees/pages/employees-detail/employees-detail.component.spec.ts
@@ -1,28 +1,23 @@
-/* tslint:disable:no-unused-variable */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
-
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { EmployeesDetailComponent } from './employees-detail.component';
 
 describe('EmployeesDetailComponent', () => {
-  let component: EmployeesDetailComponent;
-  let fixture: ComponentFixture<EmployeesDetailComponent>;
-
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ EmployeesDetailComponent ]
-    })
-    .compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(EmployeesDetailComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [EmployeesDetailComponent],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    const fixture = TestBed.createComponent(EmployeesDetailComponent);
+    expect(fixture.componentInstance).toBeTruthy();
   });
 });

--- a/src/app/modules/private/employees/pages/employees/employees.component.spec.ts
+++ b/src/app/modules/private/employees/pages/employees/employees.component.spec.ts
@@ -1,28 +1,15 @@
-/* tslint:disable:no-unused-variable */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
-
+import { TestBed } from '@angular/core/testing';
 import { EmployeesComponent } from './employees.component';
 
 describe('EmployeesComponent', () => {
-  let component: EmployeesComponent;
-  let fixture: ComponentFixture<EmployeesComponent>;
-
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ EmployeesComponent ]
-    })
-    .compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(EmployeesComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [EmployeesComponent],
+    }).compileComponents();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    const fixture = TestBed.createComponent(EmployeesComponent);
+    expect(fixture.componentInstance).toBeTruthy();
   });
 });

--- a/src/app/modules/private/employees/services/employees.service.spec.ts
+++ b/src/app/modules/private/employees/services/employees.service.spec.ts
@@ -1,16 +1,15 @@
-/* tslint:disable:no-unused-variable */
-
-import { TestBed, async, inject } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { EmployeesService } from './employees.service';
 
-describe('Service: Employees', () => {
+describe('EmployeesService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [EmployeesService]
+      providers: [EmployeesService],
     });
   });
 
-  it('should ...', inject([EmployeesService], (service: EmployeesService) => {
+  it('debe ser creado', () => {
+    const service = TestBed.inject(EmployeesService);
     expect(service).toBeTruthy();
-  }));
+  });
 });

--- a/src/app/modules/private/groups/pages/groups-detail/groups-detail.component.spec.ts
+++ b/src/app/modules/private/groups/pages/groups-detail/groups-detail.component.spec.ts
@@ -1,28 +1,23 @@
-/* tslint:disable:no-unused-variable */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
-
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { GroupsDetailComponent } from './groups-detail.component';
 
 describe('GroupsDetailComponent', () => {
-  let component: GroupsDetailComponent;
-  let fixture: ComponentFixture<GroupsDetailComponent>;
-
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ GroupsDetailComponent ]
-    })
-    .compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(GroupsDetailComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [GroupsDetailComponent],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    const fixture = TestBed.createComponent(GroupsDetailComponent);
+    expect(fixture.componentInstance).toBeTruthy();
   });
 });

--- a/src/app/modules/private/groups/pages/groups/groups.component.spec.ts
+++ b/src/app/modules/private/groups/pages/groups/groups.component.spec.ts
@@ -1,28 +1,15 @@
-/* tslint:disable:no-unused-variable */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
-
+import { TestBed } from '@angular/core/testing';
 import { GroupsComponent } from './groups.component';
 
 describe('GroupsComponent', () => {
-  let component: GroupsComponent;
-  let fixture: ComponentFixture<GroupsComponent>;
-
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ GroupsComponent ]
-    })
-    .compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(GroupsComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [GroupsComponent],
+    }).compileComponents();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    const fixture = TestBed.createComponent(GroupsComponent);
+    expect(fixture.componentInstance).toBeTruthy();
   });
 });

--- a/src/app/modules/private/groups/services/groups.service.spec.ts
+++ b/src/app/modules/private/groups/services/groups.service.spec.ts
@@ -1,16 +1,15 @@
-/* tslint:disable:no-unused-variable */
-
-import { TestBed, async, inject } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { GroupsService } from './groups.service';
 
-describe('Service: Groups', () => {
+describe('GroupsService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [GroupsService]
+      providers: [GroupsService],
     });
   });
 
-  it('should ...', inject([GroupsService], (service: GroupsService) => {
+  it('debe ser creado', () => {
+    const service = TestBed.inject(GroupsService);
     expect(service).toBeTruthy();
-  }));
+  });
 });

--- a/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.html
+++ b/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.html
@@ -6,8 +6,8 @@
           d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
     </div>
-    <div class="px-8 py-10">
-      <h3 class="font-bold text-3xl mb-7 text-blue-700 tracking-tight flex items-center gap-3">
+    <div class="px-4 sm:px-8 py-6 sm:py-10">
+      <h3 class="font-bold text-xl sm:text-3xl mb-5 sm:mb-7 text-blue-700 tracking-tight flex items-center gap-3">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-7 w-7 text-blue-400" fill="none" viewBox="0 0 24 24"
           stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -163,15 +163,15 @@
           }
         </div>
         <!-- Botones -->
-        <div class="modal-action flex justify-center gap-4 mt-8">
-          <button type="button" class="btn btn-ghost btn-lg text-red-600 border-red-400" (click)="close.emit()">
+        <div class="modal-action flex flex-col sm:flex-row justify-center gap-3 sm:gap-4 mt-6 sm:mt-8">
+          <button type="button" class="btn btn-ghost btn-lg w-full sm:w-auto text-red-600 border-red-400" (click)="close.emit()">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" viewBox="0 0 24 24" fill="none"
               stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
             Cancelar
           </button>
-          <button type="submit" class="btn btn-primary btn-lg shadow-lg">
+          <button type="submit" class="btn btn-primary btn-lg w-full sm:w-auto shadow-lg">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" viewBox="0 0 24 24" fill="none"
               stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />

--- a/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.spec.ts
+++ b/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.spec.ts
@@ -1,28 +1,398 @@
-/* tslint:disable:no-unused-variable */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
-
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
 import { OrderCreateEditModalComponent } from './order-create-edit-modal.component';
+import { OrdersService } from '../../services/orders.service';
+import { DevicesService } from '../../../devices/services/devices.service';
+import { GroupsService } from '../../../groups/services/groups.service';
+import { EmployeesService } from '../../../employees/services/employees.service';
+import { Order, OrderStates } from '../../models/Orders';
+import { Device, DeviceStatus } from '../../../devices/models/device.model';
+import { Group } from '../../../groups/models/groups.model';
+import { Employee, EmployeeStatus } from '../../../employees/models/employe.model';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+const mockOrder: Order = {
+  id: 'order-1',
+  description: 'Instalación banco',
+  state: OrderStates.CREATED,
+  assigneeType: 'EMPLOYEE',
+  assigneeId: 'emp-1',
+  createdAt: '2026-01-01T00:00:00',
+  updatedAt: '2026-01-01T00:00:00',
+  items: [{ deviceId: 'dev-1', originalDeviceState: DeviceStatus.GOOD_CONDITION }],
+  assignee: null,
+};
+
+const mockDevice: Device = {
+  id: 'dev-1',
+  name: 'Laptop HP',
+  brand: 'HP',
+  barcode: 'HP001',
+  status: DeviceStatus.GOOD_CONDITION,
+  createdAt: '2026-01-01T00:00:00',
+  updatedAt: null,
+  assignmentActive: false,
+  selected: false,
+};
+
+const mockEmployee: Employee = {
+  id: 'emp-1',
+  fullName: 'Juan Pérez',
+  email: 'juan@test.com',
+  documentType: 'CC',
+  documentNumber: '123456',
+  status: EmployeeStatus.ACTIVE,
+};
+
+const mockGroup: Group = {
+  id: 'group-1',
+  name: 'Grupo TI',
+  address: 'Calle 1',
+  createdAt: '2026-01-01T00:00:00',
+  updatedAt: null,
+  employees: [mockEmployee],
+};
+
+function buildProviders(orderOverride?: Order | null) {
+  const devicesServiceSpy = {
+    getAllDevices: () => of([mockDevice]),
+    hasActiveAssignmentBatch: () => of([{ deviceId: 'dev-1', active: false }]),
+    getDevicesBatch: () => of([mockDevice]),
+  };
+  const groupsServiceSpy = { getAllGroups: () => of([mockGroup]) };
+  const employeesServiceSpy = { getAllEmployees: () => of([mockEmployee]) };
+  const ordersServiceSpy = {
+    createOrder: () => of(mockOrder),
+    updateOrder: () => of(mockOrder),
+  };
+
+  return {
+    devicesServiceSpy,
+    groupsServiceSpy,
+    employeesServiceSpy,
+    ordersServiceSpy,
+    providers: [
+      { provide: DevicesService, useValue: devicesServiceSpy },
+      { provide: GroupsService, useValue: groupsServiceSpy },
+      { provide: EmployeesService, useValue: employeesServiceSpy },
+      { provide: OrdersService, useValue: ordersServiceSpy },
+    ],
+  };
+}
 
 describe('OrderCreateEditModalComponent', () => {
   let component: OrderCreateEditModalComponent;
   let fixture: ComponentFixture<OrderCreateEditModalComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ OrderCreateEditModalComponent ]
-    })
-    .compileComponents();
-  }));
+  async function setup(order: Order | null = null) {
+    const { providers } = buildProviders(order);
 
-  beforeEach(() => {
+    await TestBed.configureTestingModule({
+      imports: [OrderCreateEditModalComponent],
+      providers,
+    }).compileComponents();
+
     fixture = TestBed.createComponent(OrderCreateEditModalComponent);
     component = fixture.componentInstance;
+    if (order) component.order = order;
     fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  // ── Creación ──────────────────────────────────────────────────────────────
+  it('debe ser creado en modo crear (sin order)', async () => {
+    await setup();
+    expect(component).toBeTruthy();
   });
 
-  it('should create', () => {
+  it('debe ser creado en modo editar (con order)', async () => {
+    await setup(mockOrder);
     expect(component).toBeTruthy();
+  });
+
+  // ── initForm ──────────────────────────────────────────────────────────────
+  describe('initForm', () => {
+    it('inicia el formulario vacío en modo crear', async () => {
+      await setup();
+      expect(component.orderForm.get('description')?.value).toBe('');
+      expect(component.orderForm.get('assignedType')?.value).toBe('');
+      expect(component.orderForm.get('assigneeId')?.value).toBe('');
+      expect(component.orderForm.get('devicesIds')?.value).toEqual([]);
+    });
+
+    it('precarga valores de la orden en modo editar', async () => {
+      await setup(mockOrder);
+      expect(component.orderForm.get('description')?.value).toBe(mockOrder.description);
+      expect(component.orderForm.get('assignedType')?.value).toBe(mockOrder.assigneeType);
+      expect(component.orderForm.get('assigneeId')?.value).toBe(mockOrder.assigneeId);
+    });
+
+    it('el formulario es inválido cuando los campos requeridos están vacíos', async () => {
+      await setup();
+      expect(component.orderForm.invalid).toBeTrue();
+    });
+
+    it('el formulario es válido con todos los campos requeridos', async () => {
+      await setup();
+      component.orderForm.patchValue({
+        description: 'Descripción válida',
+        assignedType: 'EMPLOYEE',
+        assigneeId: 'emp-1',
+        devicesIds: ['dev-1'],
+      });
+      expect(component.orderForm.valid).toBeTrue();
+    });
+  });
+
+  // ── filterDevices ─────────────────────────────────────────────────────────
+  describe('filterDevices', () => {
+    it('excluye dispositivos ya seleccionados', async () => {
+      await setup();
+      component.orderForm.get('devicesIds')?.setValue(['dev-1']);
+      component.filterDevices();
+      expect(component.filteredDevices.every(d => d.id !== 'dev-1')).toBeTrue();
+    });
+
+    it('filtra por nombre cuando hay búsqueda', async () => {
+      await setup();
+      component.deviceSearch = 'laptop';
+      component.filterDevices();
+      expect(component.filteredDevices.every(d =>
+        d.name.toLowerCase().includes('laptop') ||
+        (d.brand && d.brand.toLowerCase().includes('laptop'))
+      )).toBeTrue();
+    });
+
+    it('retorna todos los no-seleccionados sin búsqueda', async () => {
+      await setup();
+      component.orderForm.get('devicesIds')?.setValue([]);
+      component.filterDevices();
+      expect(component.filteredDevices.length).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  // ── addDevice / removeDevice ───────────────────────────────────────────────
+  describe('addDevice', () => {
+    it('agrega el ID al control devicesIds', async () => {
+      await setup();
+      component.addDevice('dev-2');
+      expect(component.orderForm.get('devicesIds')?.value).toContain('dev-2');
+    });
+
+    it('limpia el término de búsqueda al agregar', async () => {
+      await setup();
+      component.deviceSearch = 'HP';
+      component.addDevice('dev-2');
+      expect(component.deviceSearch).toBe('');
+    });
+  });
+
+  describe('removeDevice', () => {
+    it('elimina el ID del control devicesIds', async () => {
+      await setup();
+      component.orderForm.get('devicesIds')?.setValue(['dev-1', 'dev-2']);
+      component.removeDevice('dev-1');
+      expect(component.orderForm.get('devicesIds')?.value).not.toContain('dev-1');
+      expect(component.orderForm.get('devicesIds')?.value).toContain('dev-2');
+    });
+  });
+
+  // ── validateDevices ───────────────────────────────────────────────────────
+  describe('validateDevices', () => {
+    it('incluye dispositivos en GOOD_CONDITION sin asignación activa', async () => {
+      await setup();
+      const devices: Device[] = [
+        { ...mockDevice, id: 'd1', status: DeviceStatus.GOOD_CONDITION, assignmentActive: false },
+      ];
+      const result = component.validateDevices(devices);
+      expect(result.length).toBe(1);
+    });
+
+    it('excluye dispositivos con asignación activa', async () => {
+      await setup();
+      const devices: Device[] = [
+        { ...mockDevice, id: 'd2', status: DeviceStatus.GOOD_CONDITION, assignmentActive: true },
+      ];
+      const result = component.validateDevices(devices);
+      expect(result.length).toBe(0);
+    });
+
+    it('excluye dispositivos con estado diferente a GOOD_CONDITION', async () => {
+      await setup();
+      const devices: Device[] = [
+        { ...mockDevice, id: 'd3', status: DeviceStatus.NEEDS_REPAIR, assignmentActive: false },
+      ];
+      const result = component.validateDevices(devices);
+      expect(result.length).toBe(0);
+    });
+
+    it('incluye dispositivos que ya están en la orden aunque tengan asignación activa', async () => {
+      await setup(mockOrder);
+      const devices: Device[] = [
+        { ...mockDevice, id: 'dev-1', status: DeviceStatus.GOOD_CONDITION, assignmentActive: true },
+      ];
+      const result = component.validateDevices(devices);
+      expect(result.length).toBe(1);
+    });
+  });
+
+  // ── validateGroups ────────────────────────────────────────────────────────
+  describe('validateGroups', () => {
+    it('incluye grupos con al menos un empleado ACTIVE', async () => {
+      await setup();
+      const result = component.validateGroups([mockGroup]);
+      expect(result.length).toBe(1);
+    });
+
+    it('excluye grupos sin empleados', async () => {
+      await setup();
+      const groupSinEmpleados: Group = { ...mockGroup, employees: [] };
+      const result = component.validateGroups([groupSinEmpleados]);
+      expect(result.length).toBe(0);
+    });
+
+    it('excluye grupos con solo empleados INACTIVE', async () => {
+      await setup();
+      const groupInactivo: Group = {
+        ...mockGroup,
+        employees: [{ ...mockEmployee, status: EmployeeStatus.INACTIVE }],
+      };
+      const result = component.validateGroups([groupInactivo]);
+      expect(result.length).toBe(0);
+    });
+  });
+
+  // ── onSubmit ──────────────────────────────────────────────────────────────
+  describe('onSubmit', () => {
+    it('no emite save si el formulario es inválido', async () => {
+      await setup();
+      const saveSpy = spyOn(component.save, 'emit');
+      component.onSubmit();
+      expect(saveSpy).not.toHaveBeenCalled();
+    });
+
+    it('emite save con mode "create" en modo crear', async () => {
+      const { providers, ordersServiceSpy } = buildProviders();
+
+      await TestBed.configureTestingModule({
+        imports: [OrderCreateEditModalComponent],
+        providers,
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(OrderCreateEditModalComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      spyOn(ordersServiceSpy, 'createOrder').and.returnValue(of(mockOrder));
+      const saveSpy = spyOn(component.save, 'emit');
+
+      component.orderForm.patchValue({
+        description: 'Nueva orden',
+        assignedType: 'EMPLOYEE',
+        assigneeId: 'emp-1',
+        devicesIds: ['dev-1'],
+      });
+      component.onSubmit();
+      await fixture.whenStable();
+
+      expect(saveSpy).toHaveBeenCalledWith(
+        jasmine.objectContaining({ mode: 'create' })
+      );
+    });
+
+    it('emite save con mode "edit" en modo editar', async () => {
+      const { providers, ordersServiceSpy } = buildProviders(mockOrder);
+
+      await TestBed.configureTestingModule({
+        imports: [OrderCreateEditModalComponent],
+        providers,
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(OrderCreateEditModalComponent);
+      component = fixture.componentInstance;
+      component.order = mockOrder;
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      spyOn(ordersServiceSpy, 'updateOrder').and.returnValue(of(mockOrder));
+      const saveSpy = spyOn(component.save, 'emit');
+
+      component.orderForm.patchValue({ description: 'Descripción modificada' });
+      component.onSubmit();
+      await fixture.whenStable();
+
+      expect(saveSpy).toHaveBeenCalledWith(
+        jasmine.objectContaining({ mode: 'edit' })
+      );
+    });
+
+    it('establece formError cuando el servicio falla', async () => {
+      const { providers, ordersServiceSpy } = buildProviders();
+
+      await TestBed.configureTestingModule({
+        imports: [OrderCreateEditModalComponent],
+        providers,
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(OrderCreateEditModalComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      spyOn(ordersServiceSpy, 'createOrder').and.returnValue(
+        throwError(() => ({ error: { message: 'Error del servidor' } }))
+      );
+      spyOn(component.save, 'emit');
+
+      component.orderForm.patchValue({
+        description: 'Orden',
+        assignedType: 'EMPLOYEE',
+        assigneeId: 'emp-1',
+        devicesIds: ['dev-1'],
+      });
+      component.onSubmit();
+      await fixture.whenStable();
+
+      expect(component.formError).toBe('Error del servidor');
+    });
+  });
+
+  // ── onAssignedTypeChange ──────────────────────────────────────────────────
+  describe('onAssignedTypeChange', () => {
+    it('limpia assigneeId al cambiar el tipo de asignación', async () => {
+      await setup(mockOrder);
+      component.onAssignedTypeChange({});
+      expect(component.orderForm.get('assigneeId')?.value).toBe('');
+    });
+  });
+
+  // ── @Output close ─────────────────────────────────────────────────────────
+  describe('@Output close', () => {
+    it('el EventEmitter close está definido', async () => {
+      await setup();
+      expect(component.close).toBeDefined();
+      expect(typeof component.close.emit).toBe('function');
+    });
+  });
+
+  // ── Estado inicial ────────────────────────────────────────────────────────
+  describe('estado inicial', () => {
+    it('submitted inicia en false', async () => {
+      await setup();
+      expect(component.submitted).toBeFalse();
+    });
+
+    it('formLoading inicia en false', async () => {
+      await setup();
+      expect(component.formLoading).toBeFalse();
+    });
+
+    it('formError inicia como cadena vacía', async () => {
+      await setup();
+      expect(component.formError).toBe('');
+    });
   });
 });

--- a/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.ts
+++ b/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.ts
@@ -40,6 +40,11 @@ import { OrdersService } from '../../services/orders.service';
 import { toast } from 'ngx-sonner';
 import { EmployeeStatus } from '../../../employees/models/employe.model';
 
+/**
+ * Componente modal para crear o editar una orden, con un formulario que incluye campos para descripción, tipo de asignación, asignado a y dispositivos asociados. Gestiona la carga de datos necesarios para el formulario, validaciones, y emite eventos para guardar los cambios o cerrar el modal.
+ * @since 2026-05-11
+ * @author BunnyString
+ */
 @Component({
   selector: 'app-order-create-edit-modal',
   templateUrl: './order-create-edit-modal.component.html',

--- a/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.ts
+++ b/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.ts
@@ -171,7 +171,6 @@ export class OrderCreateEditModalComponent
           this.filterDevices();
           this.updateDeviceNameMap();
           this.cd.detectChanges();
-          console.log('Dispositivos cargados:', devices.length);
         },
         error: (error) => {
           console.error('Error al cargar dispositivos:', error);
@@ -199,7 +198,6 @@ export class OrderCreateEditModalComponent
         next: (groups) => {
           this.groups = groups;
           this.cd.detectChanges();
-          console.log('Grupos cargados:', groups.length);
         },
         error: (error) => {
           console.error('Error al cargar grupos:', error);
@@ -224,7 +222,6 @@ export class OrderCreateEditModalComponent
         next: (employees) => {
           this.employees = employees;
           this.cd.detectChanges();
-          console.log('Empleados cargados:', employees.length);
         },
         error: (error) => {
           console.error('Error al cargar empleados:', error);

--- a/src/app/modules/private/orders/modals/order-delete-modal/order-delete-modal.component.html
+++ b/src/app/modules/private/orders/modals/order-delete-modal/order-delete-modal.component.html
@@ -1,3 +1,63 @@
-<p>
-  order-delete-modal works!
-</p>
+<div class="modal modal-open z-50 bg-transparent">
+  <div class="modal-box bg-white/90 backdrop-blur-sm border border-error shadow-2xl rounded-xl relative">
+    <div class="absolute top-0 right-0 m-4 text-error pointer-events-none">
+      <svg class="h-7 w-7" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round"
+          d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7M9 10v6m6-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+      </svg>
+    </div>
+
+    <h3 class="font-bold text-xl mb-6 flex items-center gap-2 text-error">
+      <svg class="h-6 w-6 text-error flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+      ¿Eliminar orden?
+    </h3>
+
+    <p class="mb-4 text-base text-base-content/80">
+      ¿Estás seguro de que deseas eliminar la orden
+      <b class="text-error">{{ order?.description || order?.id }}</b>?
+    </p>
+
+    <div class="alert alert-warning mb-6 text-sm flex gap-2 items-start">
+      <svg class="h-5 w-5 shrink-0 mt-0.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+      Esta acción no se puede deshacer. Se eliminarán todos los dispositivos asociados a la orden.
+    </div>
+
+    @if (error) {
+      <div class="alert alert-error mb-4 text-sm flex gap-2 items-center">
+        <svg class="h-5 w-5 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+        {{ error }}
+      </div>
+    }
+
+    @if (loading) {
+      <div class="flex justify-center mb-4">
+        <span class="loading loading-spinner loading-lg text-error"></span>
+      </div>
+    }
+
+    <div class="modal-action flex flex-col sm:flex-row justify-end gap-3">
+      <button class="btn btn-ghost btn-lg w-full sm:w-auto" (click)="cancelDelete()" [disabled]="loading">
+        <svg class="h-5 w-5 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+        Cancelar
+      </button>
+      <button class="btn btn-error btn-lg w-full sm:w-auto" (click)="deleted.emit()" [disabled]="loading">
+        @if (loading) {
+          <span class="loading loading-spinner loading-xs mr-1"></span>
+        }
+        <svg class="h-5 w-5 mr-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round"
+            d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7M9 10v6m6-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+        </svg>
+        Eliminar
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/app/modules/private/orders/modals/order-delete-modal/order-delete-modal.component.spec.ts
+++ b/src/app/modules/private/orders/modals/order-delete-modal/order-delete-modal.component.spec.ts
@@ -1,28 +1,105 @@
-/* tslint:disable:no-unused-variable */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
-
+import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { OrderDeleteModalComponent } from './order-delete-modal.component';
+import { Order, OrderStates } from '../../models/Orders';
+
+const mockOrder: Order = {
+  id: 'order-1',
+  description: 'Instalación de equipos banco',
+  state: OrderStates.CREATED,
+  assigneeType: 'GROUP',
+  assigneeId: 'group-1',
+  createdAt: '2026-01-01T00:00:00',
+  updatedAt: '2026-01-01T00:00:00',
+  items: [],
+  assignee: null,
+};
 
 describe('OrderDeleteModalComponent', () => {
   let component: OrderDeleteModalComponent;
   let fixture: ComponentFixture<OrderDeleteModalComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ OrderDeleteModalComponent ]
-    })
-    .compileComponents();
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [OrderDeleteModalComponent],
+    }).compileComponents();
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(OrderDeleteModalComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('debe ser creado', () => {
     expect(component).toBeTruthy();
+  });
+
+  // ── Estado inicial ────────────────────────────────────────────────────────
+  it('loading inicia en false', () => {
+    expect(component.loading).toBeFalse();
+  });
+
+  it('error inicia como cadena vacía', () => {
+    expect(component.error).toBe('');
+  });
+
+  it('order inicia en null sin @Input', () => {
+    expect(component.order).toBeNull();
+  });
+
+  // ── @Input order ──────────────────────────────────────────────────────────
+  describe('@Input order', () => {
+    it('refleja la orden asignada por Input', async () => {
+      component.order = mockOrder;
+      await fixture.whenStable();
+      expect(component.order).toEqual(mockOrder);
+    });
+
+    it('expone la descripción de la orden asignada', () => {
+      component.order = mockOrder;
+      expect(component.order?.description).toBe('Instalación de equipos banco');
+    });
+
+    it('acepta null como valor de @Input', () => {
+      component.order = null;
+      expect(component.order).toBeNull();
+    });
+  });
+
+  // ── cancelDelete ──────────────────────────────────────────────────────────
+  describe('cancelDelete', () => {
+    it('emite el evento cancel', () => {
+      const emitSpy = spyOn(component.cancel, 'emit');
+      component.cancelDelete();
+      expect(emitSpy).toHaveBeenCalled();
+    });
+
+    it('no emite el evento deleted al cancelar', () => {
+      const emitSpy = spyOn(component.deleted, 'emit');
+      component.cancelDelete();
+      expect(emitSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── confirmDelete ─────────────────────────────────────────────────────────
+  describe('confirmDelete', () => {
+    it('existe el método confirmDelete', () => {
+      expect(component.confirmDelete).toBeDefined();
+    });
+
+    it('se puede invocar sin errores', () => {
+      expect(() => component.confirmDelete()).not.toThrow();
+    });
+  });
+
+  // ── @Output events ────────────────────────────────────────────────────────
+  describe('@Output events', () => {
+    it('deleted es un EventEmitter', () => {
+      expect(component.deleted).toBeDefined();
+      expect(typeof component.deleted.emit).toBe('function');
+    });
+
+    it('cancel es un EventEmitter', () => {
+      expect(component.cancel).toBeDefined();
+      expect(typeof component.cancel.emit).toBe('function');
+    });
   });
 });

--- a/src/app/modules/private/orders/modals/order-delete-modal/order-delete-modal.component.ts
+++ b/src/app/modules/private/orders/modals/order-delete-modal/order-delete-modal.component.ts
@@ -1,7 +1,11 @@
 import { Component, OnInit, EventEmitter, Input, Output } from '@angular/core';
 import { Order } from '../../models/Orders';
 
-
+/**
+ * Componente modal para confirmar la eliminación de una orden. Muestra detalles de la orden y proporciona opciones para confirmar o cancelar la eliminación. Emite eventos para que el componente padre pueda manejar la lógica de eliminación y cierre del modal.
+ * @since 2026-05-11
+ * @author BunnyString
+ */
 @Component({
   selector: 'app-order-delete-modal',
   templateUrl: './order-delete-modal.component.html',

--- a/src/app/modules/private/orders/models/Orders.ts
+++ b/src/app/modules/private/orders/models/Orders.ts
@@ -117,5 +117,10 @@ export interface OrderFormResult {
   mode: 'create' | 'edit';
 }
 
+export interface OrdersState {
+  orders: Order[];
+  isLoading: boolean;
+  error: string | null;
+}
 
 

--- a/src/app/modules/private/orders/orders.routes.ts
+++ b/src/app/modules/private/orders/orders.routes.ts
@@ -1,7 +1,5 @@
 import { Routes } from "@angular/router";
-import { OrdersComponent } from "./pages/orders/orders.component";
-import { OrdersDetailComponent } from "./pages/orders-detail/orders-detail.component";
-import { OrdersResolver } from "./resolvers/orders-resolver";
+import { ordersResolver } from "./resolvers/orders-resolver";
 
 /**
  * Rutas del módulo de órdenes con lazy loading
@@ -14,7 +12,7 @@ export const ORDERS_ROUTES: Routes = [
   {
     path: '',
     loadComponent: () => import('./pages/orders/orders.component').then(m => m.OrdersComponent),
-    resolve: { orders: OrdersResolver },
+    resolve: { orders: ordersResolver },
     data: {
       breadcrumb: 'Órdenes',
       title: 'Gestión de Órdenes',

--- a/src/app/modules/private/orders/pages/orders-detail/orders-detail.component.html
+++ b/src/app/modules/private/orders/pages/orders-detail/orders-detail.component.html
@@ -144,10 +144,10 @@
   </div>
 
   <!-- Tabla de dispositivos asociados a la orden -->
-  <div class="card bg-base-100 shadow-lg rounded-2xl mb-6 border border-blue-50 overflow-x-auto">
+  <div class="card bg-base-100 shadow-lg rounded-2xl mb-6 border border-blue-50">
     <div class="card-body">
-      <div class="flex items-center justify-between mb-4">
-        <h2 class="card-title text-2xl font-bold text-blue-700 flex items-center gap-2">
+      <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
+        <h2 class="card-title text-xl md:text-2xl font-bold text-blue-700 flex items-center gap-2">
           <svg class="w-7 h-7 text-blue-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
             <rect x="3" y="7" width="18" height="13" rx="2.5" />
             <circle cx="8.5" cy="15.5" r="1.5" class="fill-blue-300" />
@@ -170,7 +170,8 @@
           </span>
         </button>
       </div>
-      <table class="table table-zebra mt-2 text-base">
+      <div class="overflow-x-auto">
+      <table class="table table-zebra mt-2 text-base w-full">
         <thead>
           <tr>
             <th class="text-left">Dispositivo</th>
@@ -215,6 +216,7 @@
           }
         </tbody>
       </table>
+      </div>
     </div>
   </div>
 </div>

--- a/src/app/modules/private/orders/pages/orders-detail/orders-detail.component.spec.ts
+++ b/src/app/modules/private/orders/pages/orders-detail/orders-detail.component.spec.ts
@@ -1,28 +1,321 @@
-/* tslint:disable:no-unused-variable */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
-
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { Location } from '@angular/common';
+import { Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
+import { provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
 import { OrdersDetailComponent } from './orders-detail.component';
+import { OrdersService } from '../../services/orders.service';
+import { LoadingService } from '../../../../../core/services/loading.service';
+import { DevicesService } from '../../../devices/services/devices.service';
+import { EmployeesService } from '../../../employees/services/employees.service';
+import { GroupsService } from '../../../groups/services/groups.service';
+import { Order, OrderStates, OrderStatusColors } from '../../models/Orders';
+import { Device, DeviceStatus, DeviceStatusLabels, DeviceStatusColors } from '../../../devices/models/device.model';
+import { Employee, EmployeeStatus } from '../../../employees/models/employe.model';
+import { Group } from '../../../groups/models/groups.model';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+const mockDevice: Device = {
+  id: 'dev-1',
+  name: 'Laptop HP',
+  brand: 'HP',
+  barcode: 'HP001',
+  status: DeviceStatus.GOOD_CONDITION,
+  createdAt: '2026-01-01T00:00:00',
+  updatedAt: null,
+};
+
+const mockEmployee: Employee = {
+  id: 'emp-1',
+  fullName: 'Juan Pérez',
+  email: 'juan@test.com',
+  documentType: 'CC',
+  documentNumber: '123456',
+  status: EmployeeStatus.ACTIVE,
+};
+
+const mockGroup: Group = {
+  id: 'group-1',
+  name: 'Grupo TI',
+  address: 'Calle 1',
+  createdAt: '2026-01-01T00:00:00',
+  updatedAt: null,
+  employees: [mockEmployee],
+};
+
+const mockOrder: Order = {
+  id: 'abc12345-full-uuid',
+  description: 'Instalación de equipos',
+  state: OrderStates.CREATED,
+  assigneeType: 'EMPLOYEE',
+  assigneeId: 'emp-1',
+  createdAt: '2026-01-01T00:00:00',
+  updatedAt: '2026-01-01T00:00:00',
+  items: [{ deviceId: 'dev-1', originalDeviceState: DeviceStatus.GOOD_CONDITION }],
+  assignee: null,
+};
+
+function buildProviders(
+  orderId = 'abc12345-full-uuid',
+  orderResult: Order | null = mockOrder,
+  assigneeType: 'EMPLOYEE' | 'GROUP' = 'EMPLOYEE',
+) {
+  const order = orderResult
+    ? { ...orderResult, assigneeType }
+    : null;
+
+  const ordersServiceSpy = {
+    getOrderById: () => (order ? of(order) : throwError(() => ({ error: { message: 'Not found' } }))),
+  };
+  const devicesServiceSpy = {
+    getDevicesBatch: () => of([mockDevice]),
+  };
+  const employeesServiceSpy = {
+    getEmployeeById: () => of(mockEmployee),
+  };
+  const groupsServiceSpy = {
+    getGroupById: () => of(mockGroup),
+  };
+
+  return {
+    ordersServiceSpy,
+    devicesServiceSpy,
+    employeesServiceSpy,
+    groupsServiceSpy,
+    providers: [
+      provideRouter([]),
+      { provide: OrdersService, useValue: ordersServiceSpy },
+      { provide: DevicesService, useValue: devicesServiceSpy },
+      { provide: EmployeesService, useValue: employeesServiceSpy },
+      { provide: GroupsService, useValue: groupsServiceSpy },
+      { provide: LoadingService, useValue: { loading$: of(false) } },
+      {
+        provide: ActivatedRoute,
+        useValue: { params: of({ id: orderId }) },
+      },
+    ],
+  };
+}
 
 describe('OrdersDetailComponent', () => {
   let component: OrdersDetailComponent;
   let fixture: ComponentFixture<OrdersDetailComponent>;
+  let locationSpy: jasmine.SpyObj<Location>;
+  let router: Router;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ OrdersDetailComponent ]
-    })
-    .compileComponents();
-  }));
+  async function setup(
+    orderId = 'abc12345-full-uuid',
+    orderResult: Order | null = mockOrder,
+    assigneeType: 'EMPLOYEE' | 'GROUP' = 'EMPLOYEE',
+  ) {
+    locationSpy = jasmine.createSpyObj('Location', ['back']);
+    const { providers } = buildProviders(orderId, orderResult, assigneeType);
 
-  beforeEach(() => {
+    await TestBed.configureTestingModule({
+      imports: [OrdersDetailComponent],
+      providers: [
+        ...providers,
+        { provide: Location, useValue: locationSpy },
+      ],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(OrdersDetailComponent);
     component = fixture.componentInstance;
+    router = TestBed.inject(Router);
     fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  // ── Creación ──────────────────────────────────────────────────────────────
+  it('debe ser creado', async () => {
+    await setup();
+    expect(component).toBeTruthy();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  // ── getShortId ────────────────────────────────────────────────────────────
+  describe('getShortId', () => {
+    it('retorna los primeros 8 caracteres del UUID', async () => {
+      await setup();
+      expect(component.getShortId('abc12345-full-uuid')).toBe('abc12345');
+    });
+
+    it('retorna el string completo si tiene menos de 8 chars', async () => {
+      await setup();
+      expect(component.getShortId('ab')).toBe('ab');
+    });
+  });
+
+  // ── goBack ────────────────────────────────────────────────────────────────
+  describe('goBack', () => {
+    it('llama a location.back()', async () => {
+      await setup();
+      component.goBack();
+      expect(locationSpy.back).toHaveBeenCalled();
+    });
+  });
+
+  // ── getDeviceStatusLabel ──────────────────────────────────────────────────
+  describe('getDeviceStatusLabel', () => {
+    it('retorna la etiqueta correcta para GOOD_CONDITION', async () => {
+      await setup();
+      expect(component.getDeviceStatusLabel(DeviceStatus.GOOD_CONDITION))
+        .toBe(DeviceStatusLabels[DeviceStatus.GOOD_CONDITION]);
+    });
+
+    it('retorna la etiqueta correcta para NEEDS_REPAIR', async () => {
+      await setup();
+      expect(component.getDeviceStatusLabel(DeviceStatus.NEEDS_REPAIR))
+        .toBe(DeviceStatusLabels[DeviceStatus.NEEDS_REPAIR]);
+    });
+
+    it('retorna "-" para estado null', async () => {
+      await setup();
+      expect(component.getDeviceStatusLabel(null)).toBe('-');
+    });
+
+    it('retorna "-" para estado undefined', async () => {
+      await setup();
+      expect(component.getDeviceStatusLabel(undefined)).toBe('-');
+    });
+  });
+
+  // ── getDeviceStatusColor ──────────────────────────────────────────────────
+  describe('getDeviceStatusColor', () => {
+    it('retorna la clase CSS correcta para GOOD_CONDITION', async () => {
+      await setup();
+      const expected = 'badge-' + DeviceStatusColors[DeviceStatus.GOOD_CONDITION];
+      expect(component.getDeviceStatusColor(DeviceStatus.GOOD_CONDITION)).toBe(expected);
+    });
+
+    it('retorna badge-secondary para estado null', async () => {
+      await setup();
+      expect(component.getDeviceStatusColor(null)).toBe('badge-secondary');
+    });
+  });
+
+  // ── getOrderStateBadge ────────────────────────────────────────────────────
+  describe('getOrderStateBadge', () => {
+    it('retorna la clase CSS correcta para CREATED', async () => {
+      await setup();
+      const badge = component.getOrderStateBadge(OrderStates.CREATED);
+      expect(badge).toContain('badge badge-');
+      expect(badge).toContain(OrderStatusColors[OrderStates.CREATED]);
+    });
+
+    it('retorna badge neutral para estado null', async () => {
+      await setup();
+      expect(component.getOrderStateBadge(null)).toContain('badge-neutral');
+    });
+  });
+
+  // ── getOrderStateLabel ────────────────────────────────────────────────────
+  describe('getOrderStateLabel', () => {
+    it('retorna el estado como string para CREATED', async () => {
+      await setup();
+      expect(component.getOrderStateLabel(OrderStates.CREATED)).toBe(OrderStates.CREATED);
+    });
+
+    it('retorna "-" para estado null', async () => {
+      await setup();
+      expect(component.getOrderStateLabel(null)).toBe('-');
+    });
+
+    it('retorna "-" para estado undefined', async () => {
+      await setup();
+      expect(component.getOrderStateLabel(undefined)).toBe('-');
+    });
+  });
+
+  // ── Getters tooltip ───────────────────────────────────────────────────────
+  describe('groupNameTooltip', () => {
+    it('retorna cadena vacía cuando groupName está vacío', async () => {
+      await setup();
+      component.groupName = '';
+      expect(component.groupNameTooltip).toBe('');
+    });
+
+    it('retorna el tooltip con el nombre del grupo', async () => {
+      await setup();
+      component.groupName = 'Grupo TI';
+      expect(component.groupNameTooltip).toBe('Grupo: Grupo TI');
+    });
+  });
+
+  describe('employeeNameTooltip', () => {
+    it('retorna cadena vacía cuando no hay orden', async () => {
+      await setup(undefined, null);
+      component.order = null;
+      expect(component.employeeNameTooltip).toBe('');
+    });
+  });
+
+  // ── getOrderDetail ────────────────────────────────────────────────────────
+  describe('getOrderDetail', () => {
+    it('carga la orden correctamente desde la ruta', async () => {
+      await setup();
+      expect(component.order).toBeTruthy();
+      expect(component.order?.id).toBe(mockOrder.id);
+    });
+
+    it('establece error cuando la orden no existe', async () => {
+      await setup('bad-id', null);
+      expect(component.error).toBeTruthy();
+      expect(component.order).toBeNull();
+    });
+
+    it('carga dispositivos al obtener la orden con items', async () => {
+      await setup();
+      expect(component.order?.items).toBeDefined();
+    });
+  });
+
+  // ── refreshData ───────────────────────────────────────────────────────────
+  describe('refreshData', () => {
+    it('recarga los detalles de la orden', async () => {
+      await setup();
+      const spy = spyOn(component, 'getOrderDetail');
+      component.refreshData();
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  // ── goAsignedDetail ───────────────────────────────────────────────────────
+  describe('goAsignedDetail', () => {
+    it('navega al detalle del empleado', async () => {
+      await setup('abc12345-full-uuid', mockOrder, 'EMPLOYEE');
+      const navigateSpy = spyOn(router, 'navigate');
+      component.goAsignedDetail();
+      expect(navigateSpy).toHaveBeenCalledWith(
+        jasmine.arrayContaining(['/app/employees/'])
+      );
+    });
+
+    it('navega al detalle del grupo', async () => {
+      await setup('abc12345-full-uuid', mockOrder, 'GROUP');
+      const navigateSpy = spyOn(router, 'navigate');
+      component.goAsignedDetail();
+      expect(navigateSpy).toHaveBeenCalledWith(
+        jasmine.arrayContaining(['/app/groups/'])
+      );
+    });
+
+    it('no navega si no hay orden', async () => {
+      await setup();
+      component.order = null;
+      const navigateSpy = spyOn(router, 'navigate');
+      component.goAsignedDetail();
+      expect(navigateSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── ngOnDestroy ───────────────────────────────────────────────────────────
+  describe('ngOnDestroy', () => {
+    it('completa el subject destroy$ sin errores', async () => {
+      await setup();
+      expect(() => component.ngOnDestroy()).not.toThrow();
+    });
   });
 });

--- a/src/app/modules/private/orders/pages/orders-detail/orders-detail.component.ts
+++ b/src/app/modules/private/orders/pages/orders-detail/orders-detail.component.ts
@@ -67,7 +67,6 @@ export class OrdersDetailComponent implements OnInit, OnDestroy {
 
   // Obtener la clase CSS para el color del estado de la orden
   getOrderStateBadge(state?: OrderStates| null): string {
-    console.log('Estado de la orden:', state, 'Clase CSS:', 'badge badge-' + (state && OrderStatusColors[state] ? OrderStatusColors[state] : 'neutral') + ' text-xl p-4');
     return (
       'badge badge-' +
       (state && OrderStatusColors[state] ? OrderStatusColors[state] : 'neutral') +
@@ -149,7 +148,6 @@ export class OrdersDetailComponent implements OnInit, OnDestroy {
           this.ordersService.getOrderById(params['id']).pipe(
             tap((order) => {
               this.order = order;
-              console.log('Orden cargada:', order);
             }),
             catchError((err) => {
               this.error = err?.error?.message || 'Error al cargar orden';

--- a/src/app/modules/private/orders/pages/orders/orders.component.html
+++ b/src/app/modules/private/orders/pages/orders/orders.component.html
@@ -1,4 +1,4 @@
-@if (loading$ | async) {
+@if (isLoading()) {
   <div class="toast toast-top toast-center z-50">
     <div class="alert alert-info gap-2">
       <span class="loading loading-spinner loading-sm"></span>
@@ -34,61 +34,60 @@
         Nueva orden
       </button>
     </div>
-    <!-- Stats resumen con iconos SVG -->
-    @if (filteredOrders$ | async; as filteredOrders) {
-      @if (getStates(filteredOrders); as stats) {
-        <div class="grid grid-cols-2 md:grid-cols-4 gap-6 mb-8">
-          <div class="stat shadow-md rounded-lg">
-            <div class="stat-figure text-primary">
-              <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round"
-                  d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
-              </svg>
-            </div>
-            <div class="stat-title text-base font-semibold">Total</div>
-            <div class="stat-value text-primary text-2xl">{{ stats.totalOrders }}</div>
-            <div class="stat-desc">órdenes</div>
-          </div>
-          <div class="stat shadow-md rounded-lg">
-            <div class="stat-figure text-success">
-              <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4" />
-              </svg>
-            </div>
-            <div class="stat-title text-base font-semibold">Creadas</div>
-            <div class="stat-value text-success text-2xl">{{ stats.created }}</div>
-            <div class="stat-desc">
-              {{ (stats.totalOrders ? (stats.created / stats.totalOrders * 100) : 0) | number:'1.0-0' }}%
-            </div>
-          </div>
-          <div class="stat shadow-md rounded-lg">
-            <div class="stat-figure text-warning">
-              <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
-              </svg>
-            </div>
-            <div class="stat-title text-base font-semibold">En proceso</div>
-            <div class="stat-value text-warning text-2xl">{{ stats.inProcess }}</div>
-            <div class="stat-desc">
-              {{ (stats.totalOrders ? (stats.inProcess / stats.totalOrders * 100) : 0) | number:'1.0-0' }}%
-            </div>
-          </div>
-          <div class="stat shadow-md rounded-lg">
-            <div class="stat-figure text-success">
-              <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                <circle cx="12" cy="12" r="10" />
-                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4" />
-              </svg>
-            </div>
-            <div class="stat-title text-base font-semibold">Finalizadas</div>
-            <div class="stat-value text-success text-2xl">{{ stats.finished }}</div>
-            <div class="stat-desc">
-              {{ (stats.totalOrders ? (stats.finished / stats.totalOrders * 100) : 0) | number:'1.0-0' }}%
-            </div>
-          </div>
+
+    <!-- Stats resumen -->
+    @let stats = ordersStats();
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-6 mb-8">
+      <div class="stat shadow-md rounded-lg">
+        <div class="stat-figure text-primary">
+          <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round"
+              d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
+          </svg>
         </div>
-      }
-    }
+        <div class="stat-title text-base font-semibold">Total</div>
+        <div class="stat-value text-primary text-2xl">{{ stats.totalOrders }}</div>
+        <div class="stat-desc">órdenes</div>
+      </div>
+      <div class="stat shadow-md rounded-lg">
+        <div class="stat-figure text-success">
+          <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4" />
+          </svg>
+        </div>
+        <div class="stat-title text-base font-semibold">Creadas</div>
+        <div class="stat-value text-success text-2xl">{{ stats.created }}</div>
+        <div class="stat-desc">
+          {{ (stats.totalOrders ? (stats.created / stats.totalOrders * 100) : 0) | number:'1.0-0' }}%
+        </div>
+      </div>
+      <div class="stat shadow-md rounded-lg">
+        <div class="stat-figure text-warning">
+          <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+          </svg>
+        </div>
+        <div class="stat-title text-base font-semibold">En proceso</div>
+        <div class="stat-value text-warning text-2xl">{{ stats.inProcess }}</div>
+        <div class="stat-desc">
+          {{ (stats.totalOrders ? (stats.inProcess / stats.totalOrders * 100) : 0) | number:'1.0-0' }}%
+        </div>
+      </div>
+      <div class="stat shadow-md rounded-lg">
+        <div class="stat-figure text-success">
+          <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <circle cx="12" cy="12" r="10" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4" />
+          </svg>
+        </div>
+        <div class="stat-title text-base font-semibold">Finalizadas</div>
+        <div class="stat-value text-success text-2xl">{{ stats.finished }}</div>
+        <div class="stat-desc">
+          {{ (stats.totalOrders ? (stats.finished / stats.totalOrders * 100) : 0) | number:'1.0-0' }}%
+        </div>
+      </div>
+    </div>
+
     <!-- FILTROS -->
     <div class="flex flex-row flex-wrap items-center gap-4 mb-4">
       <div class="relative w-full sm:w-64">
@@ -104,10 +103,7 @@
           [ngModel]="statusFilter" (ngModelChange)="statusFilter = $event">
           <option [ngValue]="'ALL'">Todos los estados</option>
           @for (s of [OrderStates.CREATED, OrderStates.IN_PROCESS, OrderStates.DISPATCHED, OrderStates.FINISHED]; track s) {
-            <option
-              [ngValue]="s">
-              {{ OrderStateLabels[s] }}
-            </option>
+            <option [ngValue]="s">{{ OrderStateLabels[s] }}</option>
           }
         </select>
         <svg class="h-5 w-5 text-blue-400 absolute right-4 top-1/2 -translate-y-1/2 pointer-events-none" fill="none"
@@ -121,22 +117,19 @@
         </svg>
         Limpiar
       </button>
-      <button class="btn btn-ghost gap-2 ml-auto" (click)="loadOrders()" [disabled]="loading$ | async">
-        @if (loading$ | async) {
+      <button class="btn btn-ghost gap-2 ml-auto" (click)="loadOrders()" [disabled]="isLoading()">
+        @if (isLoading()) {
           <span class="loading loading-spinner loading-xs"></span>
-        }
-        @if (!(loading$ | async)) {
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none"
-            viewBox="0 0 24 24" stroke="currentColor">
+        } @else {
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
               d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
           </svg>
         }
-        <span class="hidden sm:inline">
-          {{ (loading$ | async) ? 'Actualizando...' : 'Actualizar' }}
-        </span>
+        <span class="hidden sm:inline">{{ isLoading() ? 'Actualizando...' : 'Actualizar' }}</span>
       </button>
     </div>
+
     <!-- MODALES -->
     @if (showCreateModal || showEditModal) {
       <app-order-create-edit-modal [order]="orderToEdit"
@@ -144,314 +137,276 @@
       </app-order-create-edit-modal>
     }
     @if (showDeleteModal) {
-      <app-order-delete-modal [order]="orderToDelete" (deleted)="onDeviceDeleted()"
-      (cancel)="cancelDelete()"></app-order-delete-modal>
+      <app-order-delete-modal [order]="orderToDelete" (deleted)="onOrderDeleted()"
+        (cancel)="cancelDelete()"></app-order-delete-modal>
     }
-    <!-- TABLA principal de órdenes -->
+
+    <!-- TABLA -->
     <div class="relative">
-      @if (pagedOrders$ | async; as pagedOrders) {
-        @if (pagedOrders.length > 0) {
-          <table class="table w-full table-zebra rounded-xl shadow-lg overflow-hidden">
-            <thead class="bg-blue-100">
-              <tr>
-                <th>
-                  <svg class="h-5 w-5 text-blue-400 inline mr-2" fill="none" stroke="currentColor" stroke-width="2"
-                    viewBox="0 0 24 24">
-                    <circle cx="12" cy="12" r="10" />
-                  </svg>
-                  Estado
-                </th>
-                <th>
-                  <svg class="h-5 w-5 text-blue-400 inline mr-2" fill="none" stroke="currentColor" stroke-width="2"
-                    viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4" />
-                  </svg>
-                  Descripción
-                </th>
-                <th>
-                  <svg class="h-5 w-5 text-blue-400 inline mr-2" fill="none" stroke="currentColor" stroke-width="2"
-                    viewBox="0 0 24 24">
-                    <rect x="6" y="9" width="12" height="6" rx="3" />
-                    <circle cx="9" cy="12" r="2" />
-                    <circle cx="15" cy="12" r="2" />
-                  </svg>
-                  Responsable
-                </th>
-                <th>
-                  <svg class="h-5 w-5 text-blue-400 inline mr-2" fill="none" stroke="currentColor" stroke-width="2"
-                    viewBox="0 0 24 24">
-                    <rect x="6" y="6" width="12" height="12" rx="3" />
-                  </svg>
-                  Tipo Asignación
-                </th>
-                <th>
-                  <svg class="h-5 w-5 text-blue-400 inline mr-2" fill="none" stroke="currentColor" stroke-width="2"
-                    viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                      d="M13 10V3L4 14h7v7l9-11h-7z" />
-                  </svg>
-                  Creada
-                </th>
-                <th class="text-center">
-                  <svg class="h-5 w-5 text-blue-400 inline mr-2" fill="none" stroke="currentColor" stroke-width="2"
-                    viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                  Acciones
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              @for (order of pagedOrders; track order) {
-                <tr class="hover:bg-blue-50 transition">
-                  <!-- Estado con badge -->
-                  <td>
+      @let pagedOrders = paginatedOrders();
+      @if (pagedOrders.length > 0) {
+        <div class="overflow-x-auto">
+        <table class="table w-full table-zebra rounded-xl shadow-lg overflow-hidden">
+          <thead class="bg-blue-100">
+            <tr>
+              <th>
+                <svg class="h-5 w-5 text-blue-400 inline mr-2" fill="none" stroke="currentColor" stroke-width="2"
+                  viewBox="0 0 24 24">
+                  <circle cx="12" cy="12" r="10" />
+                </svg>
+                Estado
+              </th>
+              <th>
+                <svg class="h-5 w-5 text-blue-400 inline mr-2" fill="none" stroke="currentColor" stroke-width="2"
+                  viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4" />
+                </svg>
+                Descripción
+              </th>
+              <th>
+                <svg class="h-5 w-5 text-blue-400 inline mr-2" fill="none" stroke="currentColor" stroke-width="2"
+                  viewBox="0 0 24 24">
+                  <rect x="6" y="9" width="12" height="6" rx="3" />
+                  <circle cx="9" cy="12" r="2" />
+                  <circle cx="15" cy="12" r="2" />
+                </svg>
+                Responsable
+              </th>
+              <th>
+                <svg class="h-5 w-5 text-blue-400 inline mr-2" fill="none" stroke="currentColor" stroke-width="2"
+                  viewBox="0 0 24 24">
+                  <rect x="6" y="6" width="12" height="12" rx="3" />
+                </svg>
+                Tipo Asignación
+              </th>
+              <th>
+                <svg class="h-5 w-5 text-blue-400 inline mr-2" fill="none" stroke="currentColor" stroke-width="2"
+                  viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M13 10V3L4 14h7v7l9-11h-7z" />
+                </svg>
+                Creada
+              </th>
+              <th class="text-center">
+                <svg class="h-5 w-5 text-blue-400 inline mr-2" fill="none" stroke="currentColor" stroke-width="2"
+                  viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+                Acciones
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (order of pagedOrders; track order.id) {
+              <tr class="hover:bg-blue-50 transition">
+                <td>
+                  <span
+                    class="badge badge-lg px-5 min-w-[120px] text-base font-semibold whitespace-nowrap flex items-center gap-2"
+                    [ngClass]="OrderStatusColors[order.state]">
+                    @if (order.state === OrderStates.FINISHED) {
+                      <svg class="h-5 w-5 text-success" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4" />
+                      </svg>
+                    }
+                    @if (order.state === OrderStates.CREATED) {
+                      <svg class="h-5 w-5 text-blue-400" fill="none" viewBox="0 0 24 24">
+                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="#3B82F6" fill-opacity="0.1" />
+                        <circle cx="12" cy="12" r="3" fill="#3B82F6" />
+                      </svg>
+                    }
+                    @if (order.state === OrderStates.DISPATCHED) {
+                      <svg class="h-5 w-5 text-primary" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                        <polygon points="9,12 17,8 17,16" fill="currentColor" />
+                        <rect x="6" y="6" width="12" height="12" rx="4" stroke="currentColor" stroke-width="2" fill="none" />
+                      </svg>
+                    }
+                    @if (order.state === OrderStates.IN_PROCESS) {
+                      <svg class="h-5 w-5 text-warning" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                        <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2" fill="none" />
+                        <path d="M12 8v4l3 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                      </svg>
+                    }
+                    @if (order.state === OrderStates.CREATED_WITH_ERRORS) {
+                      <svg class="h-5 w-5 text-error" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                        <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2" fill="none" />
+                        <path d="M12 8v4l3 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                      </svg>
+                    }
+                    {{ OrderStateLabels[order.state] }}
+                  </span>
+                </td>
+                <td class="max-w-[280px] truncate">{{ order.description }}</td>
+                <td (click)="goToAssignee(order)" class="cursor-pointer">
+                  <div class="flex items-center max-w-[180px] gap-2">
                     <span
-                      class="badge badge-lg px-5 min-w-[120px] text-base font-semibold whitespace-nowrap flex items-center gap-2"
-                      [ngClass]="OrderStatusColors[order.state]">
-                      @if (order.state === OrderStates.FINISHED) {
-                        <svg class="h-5 w-5 text-success" fill="none"
-                          stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4" />
-                        </svg>
-                      }
-                      @if (order.state === OrderStates.CREATED) {
-                        <svg class="h-5 w-5 text-blue-400" fill="none"
-                          viewBox="0 0 24 24">
-                          <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="#3B82F6"
-                            fill-opacity="0.1" />
-                          <circle cx="12" cy="12" r="3" fill="#3B82F6" />
-                        </svg>
-                      }
-                      @if (order.state === OrderStates.DISPATCHED) {
-                        <svg class="h-5 w-5 text-primary" fill="none"
-                          stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                          <polygon points="9,12 17,8 17,16" fill="currentColor" />
-                          <rect x="6" y="6" width="12" height="12" rx="4" stroke="currentColor" stroke-width="2"
-                            fill="none" />
-                        </svg>
-                      }
-                      @if (order.state === OrderStates.IN_PROCESS) {
-                        <svg class="h-5 w-5 text-warning" fill="none"
-                          stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                          <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2" fill="none" />
-                          <path d="M12 8v4l3 2" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-                            stroke-linejoin="round" />
-                        </svg>
-                      }
-                      @if (order.state === OrderStates.CREATED_WITH_ERRORS) {
-                        <svg class="h-5 w-5 text-error" fill="none"
-                          stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                          <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2" fill="none" />
-                          <path d="M12 8v4l3 2" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-                            stroke-linejoin="round" />
-                        </svg>
-                      }
-                      {{ OrderStateLabels[order.state] }}
-                    </span>
-                  </td>
-                  <td class="max-w-[280px] truncate">{{ order.description }}</td>
-                  <td (click)="verDetalle(order)" class="cursor-pointer">
-                    <div class="flex items-center max-w-[180px] gap-2">
-                      <span
-                        class="badge badge-outline px-3 py-2 rounded-full bg-blue-50 text-blue-800 font-semibold flex items-center whitespace-nowrap overflow-hidden truncate"
-                    [ngClass]="{
+                      class="badge badge-outline px-3 py-2 rounded-full bg-blue-50 text-blue-800 font-semibold flex items-center whitespace-nowrap overflow-hidden truncate"
+                      [ngClass]="{
                         'badge-success': order.assigneeType === 'EMPLOYEE',
                         'badge-info': order.assigneeType === 'GROUP'
-                      }" [attr.title]="order.assigneeType === 'GROUP'
+                      }"
+                      [attr.title]="order.assigneeType === 'GROUP'
                         ? (order.assignee?.name + ' (' + order.assignee?.employees?.length + ' emplead@s)')
-                        : order.assignee?.fullName || order.assignee?.name
-                      ">
+                        : order.assignee?.fullName || order.assignee?.name">
+                      @if (order.assigneeType === 'EMPLOYEE') {
+                        <svg class="h-5 w-5 text-blue-400 mr-1 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <circle cx="12" cy="8" r="4" />
+                          <path d="M4 20c0-4 4-6 8-6s8 2 8 6" />
+                        </svg>
+                      }
+                      @if (order.assigneeType === 'GROUP') {
+                        <svg class="h-5 w-5 text-blue-600 mr-1 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <rect x="6" y="9" width="12" height="6" rx="3" />
+                          <circle cx="9" cy="12" r="2" />
+                          <circle cx="15" cy="12" r="2" />
+                        </svg>
+                      }
+                      <span class="truncate">
                         @if (order.assigneeType === 'EMPLOYEE') {
-                          <svg class="h-5 w-5 text-blue-400 mr-1 flex-shrink-0"
-                            fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <circle cx="12" cy="8" r="4" />
-                            <path d="M4 20c0-4 4-6 8-6s8 2 8 6" />
-                          </svg>
-                        }
-                        @if (order.assigneeType === 'GROUP') {
-                          <svg class="h-5 w-5 text-blue-600 mr-1 flex-shrink-0"
-                            fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <rect x="6" y="9" width="12" height="6" rx="3" />
-                            <circle cx="9" cy="12" r="2" />
-                            <circle cx="15" cy="12" r="2" />
-                          </svg>
-                        }
-                        <span class="truncate">
-                          <!-- EMPLEADO -->
-                          @if (order.assigneeType === 'EMPLOYEE') {
-                            {{ order.assignee?.fullName || order.assignee?.name || order.assigneeId }}
-                          } @else {
-                            <span class="font-bold mr-1">{{ order.assignee?.name }}</span>
-                            @if (order.assignee?.employees?.length) {
-                              <span
-                                class="badge badge-success badge-xs px-2 font-mono whitespace-nowrap">
-                                {{ order.assignee.employees.length }}
-                              </span>
-                            }
+                          {{ order.assignee?.fullName || order.assignee?.name || order.assigneeId }}
+                        } @else {
+                          <span class="font-bold mr-1">{{ order.assignee?.name }}</span>
+                          @if (order.assignee?.employees?.length) {
+                            <span class="badge badge-success badge-xs px-2 font-mono whitespace-nowrap">
+                              {{ order.assignee.employees.length }}
+                            </span>
                           }
-                          <!-- GRUPO -->
-                        </span>
+                        }
                       </span>
-                    </div>
-                  </td>
-                  <td class="justify-center text-center">
-                    <span class="badge badge-outline badge-md px-3 bg-gray-100 text-gray-700 font-medium">
-                      {{ order.assigneeType | titlecase }}
                     </span>
-                  </td>
-                  <td>
-                    <span
-                      class="badge badge-outline px-3 py-2 rounded-full bg-blue-50 text-blue-800 font-semibold flex items-center whitespace-nowrap overflow-hidden truncate">
-                      {{ order.createdAt | date }}
-                    </span>
-                  </td>
-                  <td class="flex gap-2 justify-center text-center">
-                    <button (click)="goDetailOrder(order.id) "
-                      class="btn btn-sm min-w-10 min-h-10 border-2 border-blue-400 bg-white text-blue-600 flex items-center justify-center hover:bg-blue-100 hover:border-blue-500 hover:text-blue-700 transition-all duration-150"
-                      [attr.aria-label]="'Ver detalles de la orden'" [attr.title]="'Ver detalles de la orden'"
-                      type="button">
-                      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24"
-                        stroke="currentColor" stroke-width="2">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                        <path stroke-linecap="round" stroke-linejoin="round"
-                          d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                      </svg>
-                    </button>
-                    <button
-                      class="btn btn-sm min-w-10 min-h-10 border-2 border-yellow-400 bg-white text-yellow-600 flex items-center justify-center hover:bg-yellow-100 hover:border-yellow-500 hover:text-yellow-700 transition-all duration-150"
-                      (click)="orderToEdit = order; showEditModal = true; formMode = 'edit';"
-                      [attr.aria-label]="'Editar orden'" [attr.title]="'Editar orden'" type="button">
-                      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24"
-                        stroke="currentColor" stroke-width="2">
-                        <path stroke-linecap="round" stroke-linejoin="round"
-                          d="M16.862 4.487l1.651 1.651a2.131 2.131 0 010 3.016l-9.193 9.193a1.5 1.5 0 01-.61.378l-3.12.937a.376.376 0 01-.47-.47l.938-3.12a1.5 1.5 0 01.378-.61l9.193-9.193a2.132 2.132 0 013.017 0z" />
-                      </svg>
-                    </button>
-                    <button
-                      class="btn btn-sm min-w-10 min-h-10 border-2 border-red-400 bg-white text-red-600 flex items-center justify-center hover:bg-red-100 hover:border-red-500 hover:text-red-700 transition-all duration-150"
-                      (click)="orderToDelete = order; showDeleteModal = true;" [attr.aria-label]="'Eliminar orden'"
-                      [attr.title]="'Eliminar orden'" type="button">
-                      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24"
-                        stroke="currentColor" stroke-width="2">
-                        <path stroke-linecap="round" stroke-linejoin="round"
-                          d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7M9 10v6m6-6v6m2-10V5a2 2 0 00-2-2h-4a2 2 0 00-2 2v2M4 7h16" />
-                      </svg>
-                    </button>
-                  </td>
-                </tr>
-              }
-            </tbody>
-          </table>
-        }
-        <!-- PAGINADOR MODERNO -->
-        @if (totalItems > 0) {
-          <div class="mt-8 px-4">
-            <div
-              class="flex flex-col sm:flex-row justify-between items-center gap-4 bg-base-200/50 rounded-2xl p-6 shadow-xl border border-base-300">
-              <!-- INFO: Mostrando X-Y de Z registros -->
-              <div class="flex items-center gap-3 order-2 sm:order-1">
-                <div class="badge badge-primary badge-lg gap-2 px-4 py-3">
-                  <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round"
-                      d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                  </svg>
-                  <span class="font-bold">{{ totalItems }}</span>
-                  <span class="font-normal">{{ totalItems === 1 ? 'dispositivo' : 'dispositivos' }}</span>
-                </div>
-                <div class="hidden md:flex items-center gap-2 text-sm text-base-content/70">
-                  <span>Mostrando</span>
-                  <span class="font-semibold text-primary">{{ (page - 1) * pageSize + 1 }}</span>
-                  <span>-</span>
-                  <span class="font-semibold text-primary">{{ page * pageSize > totalItems ? totalItems : page * pageSize
-                  }}</span>
-                </div>
-              </div>
-              <!-- CONTROLES DE PAGINACIÓN -->
-              <div class="order-1 sm:order-2">
-                @if (getTotalPages() > 1) {
-                  <div class="join shadow-lg">
-                    <!-- Primera página -->
-                    <button class="join-item btn btn-sm sm:btn-md hover:btn-primary transition-all duration-200"
-                      [disabled]="page === 1" (click)="goToPage(1)" title="Primera página">
-                      <svg class="h-4 w-4 sm:h-5 sm:w-5" fill="none" stroke="currentColor" stroke-width="2"
-                        viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
-                      </svg>
-                    </button>
-                    <!-- Anterior -->
-                    <button class="join-item btn btn-sm sm:btn-md gap-2 hover:btn-primary transition-all duration-200"
-                      [disabled]="page === 1" (click)="previousPage()" title="Página anterior">
-                      <svg class="h-4 w-4 sm:h-5 sm:w-5" fill="none" stroke="currentColor" stroke-width="2"
-                        viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
-                      </svg>
-                      <span class="hidden sm:inline font-medium">Anterior</span>
-                    </button>
-                    <!-- Indicador de página -->
-                    <button
-                      class="join-item btn btn-sm sm:btn-md btn-primary pointer-events-none min-w-[120px] sm:min-w-[140px]">
-                      <span class="font-bold">{{ page }}</span>
-                      <span class="mx-1">/</span>
-                      <span class="font-bold">{{ getTotalPages() }}</span>
-                    </button>
-                    <!-- Siguiente -->
-                    <button class="join-item btn btn-sm sm:btn-md gap-2 hover:btn-primary transition-all duration-200"
-                      [disabled]="page === getTotalPages()" (click)="nextPage()" title="Página siguiente">
-                      <span class="hidden sm:inline font-medium">Siguiente</span>
-                      <svg class="h-4 w-4 sm:h-5 sm:w-5" fill="none" stroke="currentColor" stroke-width="2"
-                        viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
-                      </svg>
-                    </button>
-                    <!-- Última página -->
-                    <button class="join-item btn btn-sm sm:btn-md hover:btn-primary transition-all duration-200"
-                      [disabled]="page === getTotalPages()" (click)="goToPage(getTotalPages())" title="Última página">
-                      <svg class="h-4 w-4 sm:h-5 sm:w-5" fill="none" stroke="currentColor" stroke-width="2"
-                        viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M13 5l7 7-7 7M5 5l7 7-7 7" />
-                      </svg>
-                    </button>
                   </div>
-                }
-                <!-- Mensaje cuando solo hay 1 página -->
-                @if (getTotalPages() === 1) {
-                  <div
-                    class="flex items-center gap-3 px-6 py-3 bg-success/10 rounded-full border-2 border-success/20">
-                    <svg class="w-5 h-5 text-success" fill="none" stroke="currentColor" stroke-width="2"
-                      viewBox="0 0 24 24">
+                </td>
+                <td class="justify-center text-center">
+                  <span class="badge badge-outline badge-md px-3 bg-gray-100 text-gray-700 font-medium">
+                    {{ order.assigneeType | titlecase }}
+                  </span>
+                </td>
+                <td>
+                  <span
+                    class="badge badge-outline px-3 py-2 rounded-full bg-blue-50 text-blue-800 font-semibold flex items-center whitespace-nowrap overflow-hidden truncate">
+                    {{ order.createdAt | date }}
+                  </span>
+                </td>
+                <td class="flex gap-2 justify-center text-center">
+                  <button (click)="goDetailOrder(order.id)"
+                    class="btn btn-sm min-w-10 min-h-10 border-2 border-blue-400 bg-white text-blue-600 flex items-center justify-center hover:bg-blue-100 hover:border-blue-500 hover:text-blue-700 transition-all duration-150"
+                    [attr.aria-label]="'Ver detalles de la orden'" [attr.title]="'Ver detalles de la orden'" type="button">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                       <path stroke-linecap="round" stroke-linejoin="round"
-                        d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
                     </svg>
-                    <span class="text-sm font-medium text-success">
-                      Mostrando todos los dispositivos
-                    </span>
-                  </div>
-                }
+                  </button>
+                  <button
+                    class="btn btn-sm min-w-10 min-h-10 border-2 border-yellow-400 bg-white text-yellow-600 flex items-center justify-center hover:bg-yellow-100 hover:border-yellow-500 hover:text-yellow-700 transition-all duration-150"
+                    (click)="orderToEdit = order; showEditModal = true;"
+                    [attr.aria-label]="'Editar orden'" [attr.title]="'Editar orden'" type="button">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                      <path stroke-linecap="round" stroke-linejoin="round"
+                        d="M16.862 4.487l1.651 1.651a2.131 2.131 0 010 3.016l-9.193 9.193a1.5 1.5 0 01-.61.378l-3.12.937a.376.376 0 01-.47-.47l.938-3.12a1.5 1.5 0 01.378-.61l9.193-9.193a2.132 2.132 0 013.017 0z" />
+                    </svg>
+                  </button>
+                  <button
+                    class="btn btn-sm min-w-10 min-h-10 border-2 border-red-400 bg-white text-red-600 flex items-center justify-center hover:bg-red-100 hover:border-red-500 hover:text-red-700 transition-all duration-150"
+                    (click)="orderToDelete = order; showDeleteModal = true;"
+                    [attr.aria-label]="'Eliminar orden'" [attr.title]="'Eliminar orden'" type="button">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                      <path stroke-linecap="round" stroke-linejoin="round"
+                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7M9 10v6m6-6v6m2-10V5a2 2 0 00-2-2h-4a2 2 0 00-2 2v2M4 7h16" />
+                    </svg>
+                  </button>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+        </div>
+      }
+
+      <!-- PAGINADOR -->
+      @if (totalItems() > 0) {
+        <div class="mt-8 px-4">
+          <div
+            class="flex flex-col sm:flex-row justify-between items-center gap-4 bg-base-200/50 rounded-2xl p-6 shadow-xl border border-base-300">
+            <div class="flex items-center gap-3 order-2 sm:order-1">
+              <div class="badge badge-primary badge-lg gap-2 px-4 py-3">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round"
+                    d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                </svg>
+                <span class="font-bold">{{ totalItems() }}</span>
+                <span class="font-normal">{{ totalItems() === 1 ? 'orden' : 'órdenes' }}</span>
               </div>
-              <!-- SELECTOR DE TAMAÑO DE PÁGINA -->
-              <div class="flex items-center gap-3 order-3">
-                <label class="text-sm font-medium text-base-content/70 hidden sm:inline">
-                  Por página:
-                </label>
-                <select
-                  class="select select-bordered select-sm sm:select-md w-20 sm:w-24 font-semibold hover:select-primary transition-all duration-200"
-                  [(ngModel)]="pageSize" (ngModelChange)="page = 1">
-                  <option [value]="5">5</option>
-                  <option [value]="10">10</option>
-                  <option [value]="20">20</option>
-                  <option [value]="50">50</option>
-                  <option [value]="100">100</option>
-                </select>
+              <div class="hidden md:flex items-center gap-2 text-sm text-base-content/70">
+                <span>Mostrando</span>
+                <span class="font-semibold text-primary">{{ (page - 1) * pageSize + 1 }}</span>
+                <span>-</span>
+                <span class="font-semibold text-primary">{{ page * pageSize > totalItems() ? totalItems() : page * pageSize }}</span>
               </div>
             </div>
+            <div class="order-1 sm:order-2">
+              @if (totalPages() > 1) {
+                <div class="join shadow-lg">
+                  <button class="join-item btn btn-sm sm:btn-md hover:btn-primary transition-all duration-200"
+                    [disabled]="page === 1" (click)="goToPage(1)" title="Primera página">
+                    <svg class="h-4 w-4 sm:h-5 sm:w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
+                    </svg>
+                  </button>
+                  <button class="join-item btn btn-sm sm:btn-md gap-2 hover:btn-primary transition-all duration-200"
+                    [disabled]="page === 1" (click)="previousPage()" title="Página anterior">
+                    <svg class="h-4 w-4 sm:h-5 sm:w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+                    </svg>
+                    <span class="hidden sm:inline font-medium">Anterior</span>
+                  </button>
+                  <button class="join-item btn btn-sm sm:btn-md btn-primary pointer-events-none min-w-[120px] sm:min-w-[140px]">
+                    <span class="font-bold">{{ page }}</span>
+                    <span class="mx-1">/</span>
+                    <span class="font-bold">{{ totalPages() }}</span>
+                  </button>
+                  <button class="join-item btn btn-sm sm:btn-md gap-2 hover:btn-primary transition-all duration-200"
+                    [disabled]="page === totalPages()" (click)="nextPage()" title="Página siguiente">
+                    <span class="hidden sm:inline font-medium">Siguiente</span>
+                    <svg class="h-4 w-4 sm:h-5 sm:w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                    </svg>
+                  </button>
+                  <button class="join-item btn btn-sm sm:btn-md hover:btn-primary transition-all duration-200"
+                    [disabled]="page === totalPages()" (click)="goToPage(totalPages())" title="Última página">
+                    <svg class="h-4 w-4 sm:h-5 sm:w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M13 5l7 7-7 7M5 5l7 7-7 7" />
+                    </svg>
+                  </button>
+                </div>
+              }
+              @if (totalPages() === 1) {
+                <div class="flex items-center gap-3 px-6 py-3 bg-success/10 rounded-full border-2 border-success/20">
+                  <svg class="w-5 h-5 text-success" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round"
+                      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  <span class="text-sm font-medium text-success">Mostrando todas las órdenes</span>
+                </div>
+              }
+            </div>
+            <div class="flex items-center gap-3 order-3">
+              <label class="text-sm font-medium text-base-content/70 hidden sm:inline">Por página:</label>
+              <select
+                class="select select-bordered select-sm sm:select-md w-20 sm:w-24 font-semibold hover:select-primary transition-all duration-200"
+                [(ngModel)]="pageSize" (ngModelChange)="page = 1">
+                <option [value]="5">5</option>
+                <option [value]="10">10</option>
+                <option [value]="20">20</option>
+                <option [value]="50">50</option>
+                <option [value]="100">100</option>
+              </select>
+            </div>
           </div>
-        }
-        @if (pagedOrders.length === 0) {
-          <div class="py-12 text-center opacity-80">
-            No hay órdenes
-          </div>
-        }
+        </div>
+      }
+
+      @if (pagedOrders.length === 0) {
+        <div class="py-12 text-center opacity-80">No hay órdenes</div>
       }
     </div>
   } @else {
@@ -461,20 +416,16 @@
         <circle cx="12" cy="12" r="10" />
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01" />
       </svg>
-      <h2 class="text-2xl font-bold mb-2 text-base-content">
-        No se pudieron cargar las órdenes
-      </h2>
+      <h2 class="text-2xl font-bold mb-2 text-base-content">No se pudieron cargar las órdenes</h2>
       <p class="text-base-content/60 mb-6 max-w-md">
         Hubo un problema al conectar con el servidor.<br>
         Por favor verifica tu conexión e intenta nuevamente.
       </p>
-      <button class="btn btn-primary gap-2" (click)="loadOrders()" [disabled]="loading$ | async">
-        @if (loading$ | async) {
+      <button class="btn btn-primary gap-2" (click)="loadOrders()" [disabled]="isLoading()">
+        @if (isLoading()) {
           <span class="loading loading-spinner loading-sm"></span>
-        }
-        @if (!(loading$ | async)) {
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none"
-            viewBox="0 0 24 24" stroke="currentColor">
+        } @else {
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
               d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
           </svg>
@@ -483,5 +434,4 @@
       </button>
     </div>
   }
-
 </div>

--- a/src/app/modules/private/orders/pages/orders/orders.component.html
+++ b/src/app/modules/private/orders/pages/orders/orders.component.html
@@ -26,7 +26,7 @@
           Gestión y seguimiento de órdenes en el sistema
         </div>
       </div>
-      <button class="btn btn-primary btn-lg gap-3 shadow-lg" (click)="showCreateModal = true"
+      <button class="btn btn-primary btn-lg gap-3 shadow-lg w-full md:w-auto" (click)="showCreateModal = true"
         [disabled]="!buttonsIsAvailable">
         <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
@@ -37,7 +37,7 @@
 
     <!-- Stats resumen -->
     @let stats = ordersStats();
-    <div class="grid grid-cols-2 md:grid-cols-4 gap-6 mb-8">
+    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6 mb-8">
       <div class="stat shadow-md rounded-lg">
         <div class="stat-figure text-primary">
           <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
@@ -98,7 +98,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
         </svg>
       </div>
-      <div class="relative w-44">
+      <div class="relative w-full sm:w-44">
         <select class="select select-bordered w-full bg-white/90 shadow focus:ring-2 focus:ring-blue-400"
           [ngModel]="statusFilter" (ngModelChange)="statusFilter = $event">
           <option [ngValue]="'ALL'">Todos los estados</option>

--- a/src/app/modules/private/orders/pages/orders/orders.component.spec.ts
+++ b/src/app/modules/private/orders/pages/orders/orders.component.spec.ts
@@ -1,28 +1,348 @@
-/* tslint:disable:no-unused-variable */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
-
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { provideRouter } from '@angular/router';
+import { of } from 'rxjs';
 import { OrdersComponent } from './orders.component';
+import { OrdersStore } from '../../store/orders.store';
+import { LoadingService } from '../../../../../core/services/loading.service';
+import { Order, OrderStates, OrderFormResult } from '../../models/Orders';
+import { toast } from 'ngx-sonner';
+
+const mockOrder: Order = {
+  id: 'order-1',
+  description: 'Instalación de equipos banco',
+  state: OrderStates.CREATED,
+  assigneeType: 'GROUP',
+  assigneeId: 'group-1',
+  createdAt: '2026-01-01T00:00:00',
+  updatedAt: '2026-01-01T00:00:00',
+  items: [],
+  assignee: { id: 'group-1', name: 'Grupo Test' },
+};
+
+function buildMockStore(orders: Order[] = [], error: string | null = null) {
+  return {
+    orders: () => orders,
+    error: () => error,
+    isLoading: () => false,
+    loadOrders: () => of([]),
+    clearError: () => {},
+    upsertOrder: (_order: Order) => {},
+    removeOrder: (_id: string) => {},
+    stats: () => ({}),
+  };
+}
 
 describe('OrdersComponent', () => {
   let component: OrdersComponent;
   let fixture: ComponentFixture<OrdersComponent>;
+  let router: Router;
+  let mockStore: ReturnType<typeof buildMockStore>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ OrdersComponent ]
-    })
-    .compileComponents();
-  }));
+  async function setup(orders: Order[] = [], error: string | null = null) {
+    mockStore = buildMockStore(orders, error);
 
-  beforeEach(() => {
+    await TestBed.configureTestingModule({
+      imports: [OrdersComponent],
+      providers: [
+        provideRouter([]),
+        { provide: OrdersStore, useValue: mockStore },
+        { provide: LoadingService, useValue: { loading$: of(false) } },
+      ],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(OrdersComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    router = TestBed.inject(Router);
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('debe ser creado', async () => {
+    await setup();
+    expect(component).toBeTruthy();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  // ── ngOnInit ──────────────────────────────────────────────────────────────
+  describe('ngOnInit', () => {
+    it('muestra toast.error cuando el store tiene error', async () => {
+      await setup([], 'Error de red');
+      spyOn(toast, 'error');
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(toast.error).toHaveBeenCalledWith('No se pudo conectar al microservicio de órdenes.');
+    });
+
+    it('muestra toast.info cuando no hay error y lista vacía', async () => {
+      await setup([]);
+      spyOn(toast, 'info');
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(toast.info).toHaveBeenCalledWith('No hay órdenes para mostrar actualmente.');
+    });
+
+    it('no muestra toast cuando hay órdenes y sin error', async () => {
+      await setup([mockOrder]);
+      spyOn(toast, 'info');
+      spyOn(toast, 'error');
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(toast.info).not.toHaveBeenCalled();
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Filtros ───────────────────────────────────────────────────────────────
+  describe('filteredOrders', () => {
+    const orders: Order[] = [
+      { ...mockOrder, id: '1', description: 'Instalación banco', state: OrderStates.CREATED },
+      { ...mockOrder, id: '2', description: 'Mantenimiento equipo', state: OrderStates.IN_PROCESS },
+      { ...mockOrder, id: '3', description: 'Envío dispositivos', state: OrderStates.FINISHED },
+    ];
+
+    beforeEach(async () => {
+      await setup(orders);
+      fixture.detectChanges();
+    });
+
+    it('retorna todas las órdenes sin filtros', () => {
+      expect(component.filteredOrders().length).toBe(3);
+    });
+
+    it('filtra por término de búsqueda en descripción', () => {
+      component.search = 'banco';
+      expect(component.filteredOrders().length).toBe(1);
+      expect(component.filteredOrders()[0].description).toBe('Instalación banco');
+    });
+
+    it('filtra por estado', () => {
+      component.statusFilter = OrderStates.FINISHED;
+      expect(component.filteredOrders().length).toBe(1);
+      expect(component.filteredOrders()[0].state).toBe(OrderStates.FINISHED);
+    });
+
+    it('combina búsqueda y estado sin resultados', () => {
+      component.search = 'instalación';
+      component.statusFilter = OrderStates.IN_PROCESS;
+      expect(component.filteredOrders().length).toBe(0);
+    });
+
+    it('resetea la página a 1 al cambiar búsqueda', () => {
+      component.page = 2;
+      component.search = 'test';
+      expect(component.page).toBe(1);
+    });
+
+    it('resetea la página a 1 al cambiar filtro de estado', () => {
+      component.page = 2;
+      component.statusFilter = OrderStates.CREATED;
+      expect(component.page).toBe(1);
+    });
+  });
+
+  // ── Paginación ────────────────────────────────────────────────────────────
+  describe('paginación', () => {
+    beforeEach(async () => {
+      const orders: Order[] = Array.from({ length: 25 }, (_, i) => ({
+        ...mockOrder,
+        id: `order-${i}`,
+        description: `Orden ${i}`,
+      }));
+      await setup(orders);
+      fixture.detectChanges();
+    });
+
+    it('calcula totalPages correctamente (25 items / 10 = 3)', () => {
+      expect(component.totalPages()).toBe(3);
+    });
+
+    it('retorna 10 ítems en la primera página', () => {
+      expect(component.paginatedOrders().length).toBe(10);
+    });
+
+    it('nextPage incrementa la página', () => {
+      component.nextPage();
+      expect(component.page).toBe(2);
+    });
+
+    it('previousPage decrementa la página', () => {
+      component.page = 2;
+      component.previousPage();
+      expect(component.page).toBe(1);
+    });
+
+    it('goToPage no navega debajo de la página 1', () => {
+      component.goToPage(0);
+      expect(component.page).toBe(1);
+    });
+
+    it('goToPage no navega más allá de totalPages', () => {
+      component.goToPage(999);
+      expect(component.page).toBe(1);
+    });
+
+    it('totalItems refleja el número de órdenes filtradas', () => {
+      expect(component.totalItems()).toBe(25);
+    });
+  });
+
+  // ── Modales ───────────────────────────────────────────────────────────────
+  describe('closeModals', () => {
+    it('resetea todos los estados de modal y referencias de orden', async () => {
+      await setup();
+      component.showCreateModal = true;
+      component.showEditModal = true;
+      component.showDeleteModal = true;
+      component.orderToEdit = mockOrder;
+      component.orderToDelete = mockOrder;
+      component.closeModals();
+      expect(component.showCreateModal).toBeFalse();
+      expect(component.showEditModal).toBeFalse();
+      expect(component.showDeleteModal).toBeFalse();
+      expect(component.orderToEdit).toBeNull();
+      expect(component.orderToDelete).toBeNull();
+    });
+  });
+
+  describe('handleModalSave', () => {
+    beforeEach(async () => await setup());
+
+    it('muestra "Orden creada" y recarga en modo create', () => {
+      spyOn(component, 'loadOrders');
+      spyOn(component, 'closeModals');
+      spyOn(toast, 'success');
+      component.handleModalSave({ order: mockOrder, mode: 'create' } as OrderFormResult);
+      expect(toast.success).toHaveBeenCalledWith('Orden creada');
+      expect(component.loadOrders).toHaveBeenCalled();
+      expect(component.closeModals).toHaveBeenCalled();
+    });
+
+    it('muestra "Orden actualizada" en modo edit', () => {
+      spyOn(component, 'loadOrders');
+      spyOn(component, 'closeModals');
+      spyOn(toast, 'success');
+      component.handleModalSave({ order: mockOrder, mode: 'edit' } as OrderFormResult);
+      expect(toast.success).toHaveBeenCalledWith('Orden actualizada');
+    });
+  });
+
+  describe('onOrderDeleted', () => {
+    it('resetea el estado de eliminación y recarga', async () => {
+      await setup();
+      const loadSpy = spyOn(component, 'loadOrders');
+      component.showDeleteModal = true;
+      component.orderToDelete = mockOrder;
+      component.onOrderDeleted();
+      expect(component.showDeleteModal).toBeFalse();
+      expect(component.orderToDelete).toBeNull();
+      expect(loadSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('cancelDelete', () => {
+    it('cierra el modal sin recargar órdenes', async () => {
+      await setup();
+      const loadSpy = spyOn(component, 'loadOrders');
+      component.showDeleteModal = true;
+      component.orderToDelete = mockOrder;
+      component.cancelDelete();
+      expect(component.showDeleteModal).toBeFalse();
+      expect(component.orderToDelete).toBeNull();
+      expect(loadSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('clearError', () => {
+    it('delega a store.clearError()', async () => {
+      await setup();
+      const clearSpy = spyOn(mockStore, 'clearError');
+      component.clearError();
+      expect(clearSpy).toHaveBeenCalled();
+    });
+  });
+
+  // ── Navegación ────────────────────────────────────────────────────────────
+  describe('goToAssignee', () => {
+    beforeEach(async () => await setup());
+
+    it('navega al detalle del grupo', () => {
+      const navigateSpy = spyOn(router, 'navigate');
+      const order: Order = { ...mockOrder, assigneeType: 'GROUP', assignee: { id: 'group-1' } };
+      component.goToAssignee(order);
+      expect(navigateSpy).toHaveBeenCalledWith(['/app/groups', 'group-1']);
+    });
+
+    it('navega al detalle del empleado', () => {
+      const navigateSpy = spyOn(router, 'navigate');
+      const order: Order = { ...mockOrder, assigneeType: 'EMPLOYEE', assignee: { id: 'emp-1' } };
+      component.goToAssignee(order);
+      expect(navigateSpy).toHaveBeenCalledWith(['/app/employees', 'emp-1']);
+    });
+  });
+
+  describe('goDetailOrder', () => {
+    beforeEach(async () => await setup());
+
+    it('navega al detalle de la orden con ID válido', () => {
+      const navigateSpy = spyOn(router, 'navigate');
+      component.goDetailOrder('order-123');
+      expect(navigateSpy).toHaveBeenCalledWith(['/app/orders/', 'order-123']);
+    });
+
+    it('no navega si el ID está vacío', () => {
+      const navigateSpy = spyOn(router, 'navigate');
+      component.goDetailOrder('');
+      expect(navigateSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Estadísticas ──────────────────────────────────────────────────────────
+  describe('getStates', () => {
+    beforeEach(async () => await setup());
+
+    it('calcula estadísticas para lista mixta', () => {
+      const orders: Order[] = [
+        { ...mockOrder, state: OrderStates.CREATED },
+        { ...mockOrder, state: OrderStates.CREATED },
+        { ...mockOrder, state: OrderStates.IN_PROCESS },
+        { ...mockOrder, state: OrderStates.DISPATCHED },
+        { ...mockOrder, state: OrderStates.FINISHED },
+      ];
+      const stats = component.getStates(orders);
+      expect(stats.totalOrders).toBe(5);
+      expect(stats.created).toBe(2);
+      expect(stats.inProcess).toBe(1);
+      expect(stats.dispatched).toBe(1);
+      expect(stats.finished).toBe(1);
+    });
+
+    it('retorna ceros con lista vacía', () => {
+      const stats = component.getStates([]);
+      expect(stats.totalOrders).toBe(0);
+      expect(stats.created).toBe(0);
+    });
+  });
+
+  // ── Getters de estado ─────────────────────────────────────────────────────
+  describe('orderError y buttonsIsAvailable', () => {
+    it('orderError es true cuando hay error', async () => {
+      await setup([], 'Error');
+      expect(component.orderError).toBeTrue();
+    });
+
+    it('orderError es false cuando no hay error', async () => {
+      await setup([], null);
+      expect(component.orderError).toBeFalse();
+    });
+
+    it('buttonsIsAvailable es false cuando hay error', async () => {
+      await setup([], 'Error');
+      expect(component.buttonsIsAvailable).toBeFalse();
+    });
+
+    it('buttonsIsAvailable es true cuando no hay error', async () => {
+      await setup([], null);
+      expect(component.buttonsIsAvailable).toBeTrue();
+    });
   });
 });

--- a/src/app/modules/private/orders/pages/orders/orders.component.ts
+++ b/src/app/modules/private/orders/pages/orders/orders.component.ts
@@ -1,24 +1,9 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
-import { OrdersService } from '../../services/orders.service';
+import { Component, DestroyRef, OnInit, computed, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { LoadingService } from '../../../../../core/services/loading.service';
 import { FormsModule } from '@angular/forms';
-import {
-  Subject,
-  takeUntil,
-  BehaviorSubject,
-  Observable,
-  combineLatest,
-  startWith,
-  map,
-  tap,
-  catchError,
-  concatMap,
-  of,
-  forkJoin,
-} from 'rxjs';
-import { OrderCreateEditModalComponent } from '../../modals/order-create-edit-modal/order-create-edit-modal.component';
-import { OrderDeleteModalComponent } from '../../modals/order-delete-modal/order-delete-modal.component';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { Router } from '@angular/router';
+import { toast } from 'ngx-sonner';
 import {
   Order,
   OrderStates,
@@ -26,297 +11,107 @@ import {
   OrderStatusColors,
   OrderFormResult,
 } from '../../models/Orders';
-import { Router, ActivatedRoute } from '@angular/router';
-import { EmployeesService } from '../../../employees/services/employees.service';
-import { GroupsService } from '../../../groups/services/groups.service';
-import { toast } from 'ngx-sonner';
+import { LoadingService } from '../../../../../core/services/loading.service';
+import { OrderCreateEditModalComponent } from '../../modals/order-create-edit-modal/order-create-edit-modal.component';
+import { OrderDeleteModalComponent } from '../../modals/order-delete-modal/order-delete-modal.component';
+import { OrdersStore } from '../../store/orders.store';
 
 @Component({
   selector: 'app-orders',
   templateUrl: './orders.component.html',
   styleUrls: ['./orders.component.css'],
   standalone: true,
-  imports: [
-    CommonModule,
-    FormsModule,
-    OrderCreateEditModalComponent,
-    OrderDeleteModalComponent,
-  ],
+  imports: [CommonModule, FormsModule, OrderCreateEditModalComponent, OrderDeleteModalComponent],
 })
-export class OrdersComponent implements OnInit, OnDestroy {
-  // Modales
+export class OrdersComponent implements OnInit {
+  private readonly store = inject(OrdersStore);
+  private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly isLoading = toSignal(inject(LoadingService).loading$, { initialValue: false });
+
+  // Template enums
+  readonly OrderStates = OrderStates;
+  readonly OrderStateLabels = OrderStateLabels;
+  readonly OrderStatusColors = OrderStatusColors;
+
+  // Modal state (ephemeral UI — plain properties are fine)
   showCreateModal = false;
   showEditModal = false;
   showDeleteModal = false;
-
-  // Orden seleccionada para editar o eliminar
   orderToEdit: Order | null = null;
   orderToDelete: Order | null = null;
 
-  // Modo del formulario: 'create' o 'edit'
-  formMode: 'create' | 'edit' = 'create';
+  // ── Filter & pagination state as signals ─────────────────────────────────
+  private readonly _search = signal('');
+  private readonly _statusFilter = signal<OrderStates | 'ALL'>('ALL');
+  private readonly _page = signal(1);
+  private readonly _pageSize = signal(10);
 
-  // Subject para manejar la destrucción del componente y evitar memory leaks en los subscriptions
-  private readonly destroy$ = new Subject<void>();
+  // Getter/setter pairs for ngModel and direct template assignment
+  get search() { return this._search(); }
+  set search(v: string) { this._search.set(v); this._page.set(1); }
 
-  // Observable para el estado de carga global, se puede usar para mostrar un spinner global mientras se cargan los dispositivos
-  get loading$() {
-    return this.loadingService.loading$;
-  }
+  get statusFilter() { return this._statusFilter(); }
+  set statusFilter(v: OrderStates | 'ALL') { this._statusFilter.set(v); this._page.set(1); }
 
-  // Estado de carga y error
-  submitted = false;
-  orderErrorMessage = '';
-  isRetrying = false;
-  orderError = false;
+  get page() { return this._page(); }
+  set page(v: number) { this._page.set(v); }
 
-  // Filtros como BehaviorSubject
-  search$ = new BehaviorSubject<string>('');
-  statusFilter$ = new BehaviorSubject<OrderStates | 'ALL'>('ALL');
+  get pageSize() { return this._pageSize(); }
+  set pageSize(v: number) { this._pageSize.set(v); }
 
-  // Mapas para etiquetas y colores de estado
-  get search(): string {
-    return this.search$.value;
-  }
-
-  // Getters y Setters para filtros
-  set search(val: string) {
-    this.search$.next(val);
-  }
-
-  // El filtro de estado puede ser un OrderStates o 'ALL' para mostrar todos
-  get statusFilter(): OrderStates | 'ALL' {
-    return this.statusFilter$.value;
-  }
-
-  // El setter actualiza el BehaviorSubject para que los observables dependientes se actualicen automáticamente
-  set statusFilter(val: OrderStates | 'ALL') {
-    this.statusFilter$.next(val);
-  }
-
-  // Fuente de datos principal de órdenes, se actualiza al cargar o modificar órdenes
-  orders$ = new BehaviorSubject<Order[]>([]);
-
-  // Mapas para etiquetas y colores de estado
-  OrderStates = OrderStates;
-  OrderStateLabels = OrderStateLabels;
-  OrderStatusColors = OrderStatusColors;
-
-  // Stats locales
-  stats = {
-    totalOrders: 0,
-    created: 0,
-    inProgress: 0,
-    dispatched: 0,
-    finished: 0,
-  };
-
-  // Paginación
-  page = 1;
-  pageSize = 10;
-  totalItems = 0;
-
-  // Observable de órdenes filtradas según los filtros de búsqueda y estado
-  get pagedOrders$(): Observable<Order[]> {
-    return this.filteredOrders$.pipe(
-      map((orders) =>
-        orders.slice(
-          (this.page - 1) * this.pageSize,
-          this.page * this.pageSize,
-        ),
-      ),
+  // ── Derived state as computed (memoized) ─────────────────────────────────
+  readonly filteredOrders = computed(() => {
+    const s = this._search().toLowerCase();
+    const f = this._statusFilter();
+    return this.store.orders().filter(
+      (o) => this.matchSearch(o, s) && (f === 'ALL' || o.state === f),
     );
-  }
+  });
 
-  // Lista de órdenes filtradas para mostrar en la tabla, se actualiza automáticamente cuando cambian las órdenes o los filtros
-  filteredOrders: Order[] = [];
+  readonly ordersStats = computed(() => this.getStates(this.filteredOrders()));
 
-  // Flag para controlar la disponibilidad de los botones de acción (crear, editar, eliminar)
-  buttonsIsAvailable = true;
+  readonly totalItems = computed(() => this.filteredOrders().length);
 
-  public getStates(orders: Order[]) {
-    const totalOrders = orders.length;
-    const created = orders.filter(
-      (o) => o.state === OrderStates.CREATED,
-    ).length;
-    const inProcess = orders.filter(
-      (o) => o.state === OrderStates.IN_PROCESS,
-    ).length;
-    const dispatched = orders.filter(
-      (o) => o.state === OrderStates.DISPATCHED,
-    ).length;
-    const finished = orders.filter(
-      (o) => o.state === OrderStates.FINISHED,
-    ).length;
-    return { totalOrders, created, inProcess, dispatched, finished };
-  }
+  readonly paginatedOrders = computed(() => {
+    const p = this._page();
+    const ps = this._pageSize();
+    return this.filteredOrders().slice((p - 1) * ps, p * ps);
+  });
 
-  constructor(
-    private ordersService: OrdersService,
-    private loadingService: LoadingService,
-    private employeesService: EmployeesService,
-    private groupsService: GroupsService,
-    private router: Router,
-    private route: ActivatedRoute,
-  ) {}
-
-  ngOnInit() {
-    this.initOrdersData();
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
-
-  /**
-   * Inicializa la lista de órdenes a partir de los datos resueltos por el OrdersResolver.
-   * Maneja los casos de error, lista vacía y carga exitosa, actualizando el estado del componente y mostrando mensajes adecuados.
-   * @returns void
-   */
-  initOrdersData(): void {
-    const resolved = this.route.snapshot.data['orders'];
-
-    if (resolved === 'ERROR') {
-      toast.error('No se pudo conectar al microservicio de órdenes.');
-      this.orderError = true;
-      this.orderErrorMessage = 'Error de conexión al backend.';
-      this.orders$.next([]);
-      this.buttonsIsAvailable = false;
-      return;
-    }
-
-    if (!resolved || resolved.length === 0) {
-      toast.info('No hay órdenes para mostrar actualmente.');
-      this.orderError = false;
-      this.orderErrorMessage = '';
-      this.orders$.next([]);
-      this.buttonsIsAvailable = true;
-      return;
-    }
-
-    this.buttonsIsAvailable = true;
-    this.orderError = false;
-    this.orderErrorMessage = '';
-    this.orders$.next(resolved);
-  }
-
-  /**
-   * Observable que combina la lista de órdenes con los filtros de búsqueda y estado para producir una lista filtrada de órdenes que se muestra en la tabla. Se actualiza automáticamente cada vez que cambian las órdenes o los filtros.
-   * - Combina el observable de órdenes con los filtros de búsqueda y estado usando combineLatest.
-   * - Aplica un filtro a la lista de órdenes para incluir solo aquellas que coinciden con el texto de búsqueda y el estado seleccionado.
-   * - Actualiza la propiedad totalItems para la paginación y la lista filteredOrders que se muestra en la tabla.
-   * @returns Observable<Order[]> Lista filtrada de órdenes según los criterios de búsqueda y estado.
-   */
-  filteredOrders$: Observable<Order[]> = combineLatest([
-    this.orders$,
-    this.search$.pipe(startWith('')),
-    this.statusFilter$.pipe(startWith('ALL')),
-  ]).pipe(
-    map(([orders, search, filter]) =>
-      orders.filter(
-        (o) =>
-          this.matchSearch(o, search) &&
-          (filter === 'ALL' || o.state === filter),
-      ),
-    ),
-    tap(
-      (orders) => (
-        (this.totalItems = orders.length),
-        (this.filteredOrders = orders)
-      ),
-    ),
+  readonly totalPages = computed(() =>
+    Math.ceil(this.filteredOrders().length / this._pageSize()) || 1,
   );
 
-  /** Verifica si una orden coincide con el texto de búsqueda en su nombre, marca o código de barras
-   * @param order Orden a verificar
-   * @param search Texto de búsqueda ingresado por el usuario
-   * @returns boolean Verdadero si la orden coincide con la búsqueda, falso en caso contrario
-   */
-  private matchSearch(order: Order, search: string): boolean {
-    if (!search) return true;
-    const lower = search.toLowerCase();
-    return (
-      order.description.toLowerCase().includes(lower) ||
-      order.assigneeType.toLowerCase().includes(lower) ||
-      order.state.toLowerCase().includes(lower)
-    );
+  // Error state derived from store — no effect, no state propagation
+  get orderError() { return !!this.store.error(); }
+  get buttonsIsAvailable() { return !this.store.error(); }
+
+  // ── Lifecycle ────────────────────────────────────────────────────────────
+  ngOnInit() {
+    if (this.store.error()) {
+      toast.error('No se pudo conectar al microservicio de órdenes.');
+    } else if (this.store.orders().length === 0) {
+      toast.info('No hay órdenes para mostrar actualmente.');
+    }
   }
 
-  /**
-   * Carga la lista de órdenes desde el servicio, maneja errores y actualiza las estadísticas
-   * - Limpia el mensaje de error y el flag de error antes de cargar.
-   * - Llama al servicio para obtener todas las órdenes.
-   * - Para cada orden, obtiene el responsable (empleado o grupo) según su tipo y maneja errores individuales para cada solicitud de responsable.
-   * - Combina la información del responsable con cada orden y actualiza el observable de órdenes.
-   * - Actualiza las estadísticas de órdenes según su estado.
-   * - Maneja errores globales al cargar las órdenes y muestra un mensaje de error adecuado.
-   * @returns void
-   */
+  // ── Public methods ───────────────────────────────────────────────────────
   loadOrders(): void {
-    this.orderErrorMessage = '';
-    this.orderError = false;
-    this.ordersService
-      .getAllOrders()
-      .pipe(
-        takeUntil(this.destroy$),
-        concatMap((orders) => {
-          if (!orders || orders.length === 0) return of([]);
-          // prepara la lista de observables de responsables
-          const responsibleRequests = orders.map((order) =>
-            order.assigneeType === 'EMPLOYEE'
-              ? this.employeesService
-                  .getEmployeeById(order.assigneeId)
-                  .pipe(catchError(() => of(null)))
-              : order.assigneeType === 'GROUP'
-                ? this.groupsService
-                    .getGroupById(order.assigneeId)
-                    .pipe(catchError(() => of(null)))
-                : of(null),
-          );
-          // Ejecuta todas en paralelo y mapea a cada orden
-          return forkJoin(responsibleRequests).pipe(
-            map((responsibles) =>
-              orders.map((order, i) => ({
-                ...order,
-                assignee: responsibles[i], // objeto employee o group o null
-              })),
-            ),
-          );
-        }),
-      )
-      .subscribe({
-        next: (orders) => {
-          this.orders$.next(orders);
-        },
-        error: (err) => {
-          console.error('Error al cargar órdenes:', err);
-          this.orderErrorMessage =
-            'Error al cargar órdenes. Por favor, inténtalo de nuevo.';
-          this.orderError = true;
-        },
-      });
+    this.store.loadOrders().pipe(takeUntilDestroyed(this.destroyRef)).subscribe();
   }
 
-  /**
-   * Actualiza las estadísticas de órdenes según su estado.
-   * @param orders Lista de órdenes a procesar
-   */
-
-  /**
-   * Calcula el número total de páginas para la paginación según el total de órdenes filtradas y el tamaño de página
-   * Utiliza la propiedad totalItems, que se actualiza automáticamente cuando cambia la lista de órdenes filtradas, para calcular el total de páginas
-   * @returns number Número total de páginas para la paginación
-   */
-  getTotalPages(): number {
-    return Math.ceil(this.totalItems / this.pageSize) || 1;
+  getStates(orders: Order[]) {
+    return {
+      totalOrders: orders.length,
+      created: orders.filter((o) => o.state === OrderStates.CREATED).length,
+      inProcess: orders.filter((o) => o.state === OrderStates.IN_PROCESS).length,
+      dispatched: orders.filter((o) => o.state === OrderStates.DISPATCHED).length,
+      finished: orders.filter((o) => o.state === OrderStates.FINISHED).length,
+    };
   }
 
-  /**
-   * Cierra todos los modales y limpia el estado relacionado con la edición y eliminación de dispositivos
-   * Resetea los flags de visibilidad de los modales, limpia los dispositivos seleccionados para edición y eliminación, y restablece el estado del formulario
-   * @returns void
-   */
   closeModals(): void {
     this.showCreateModal = false;
     this.showEditModal = false;
@@ -325,52 +120,28 @@ export class OrdersComponent implements OnInit, OnDestroy {
     this.orderToDelete = null;
   }
 
-  /**
-   * Maneja el resultado del formulario de creación/edición de orden
-   * Muestra un toast de éxito, recarga la lista de órdenes y cierra los modales
-   * @param result Resultado del formulario que incluye la orden creada/actualizada y el modo de operación (crear o editar)
-   * @returns void
-   */
-  handleModalSave({ order, mode }: OrderFormResult): void {
+  handleModalSave({ mode }: OrderFormResult): void {
     toast.success(mode === 'create' ? 'Orden creada' : 'Orden actualizada');
     this.loadOrders();
     this.closeModals();
   }
 
-  /** Limpia el mensaje de error
-   * @returns void
-   */
   clearError(): void {
-    this.orderErrorMessage = '';
+    this.store.clearError();
   }
 
-  /**
-   * Confirma la eliminación de la orden
-   * Llama al servicio para eliminar el dispositivo por su ID
-   * Muestra un toast de éxito o error según corresponda
-   */
-  onDeviceDeleted(): void {
+  onOrderDeleted(): void {
     this.showDeleteModal = false;
     this.orderToDelete = null;
     this.loadOrders();
   }
 
-  /**
-   * Cancela la eliminación y cierra el modal
-   * Emite un evento de cancelación para que el componente padre pueda manejarlo
-   * @returns void
-   */
   cancelDelete(): void {
     this.showDeleteModal = false;
     this.orderToDelete = null;
   }
 
-  /**
-   * Navega a la página de detalle del responsable de la orden (empleado o grupo) según su tipo
-   * @param order Orden seleccionada
-   */
-  verDetalle(order: Order): void {
-    console.log('Ver detalle del grupo:', order.assignee);
+  goToAssignee(order: Order): void {
     switch (order.assigneeType) {
       case 'GROUP':
         this.router.navigate(['/app/groups', order.assignee?.id]);
@@ -378,55 +149,29 @@ export class OrdersComponent implements OnInit, OnDestroy {
       case 'EMPLOYEE':
         this.router.navigate(['/app/employees', order.assignee?.id]);
         break;
-      default:
-        break;
     }
   }
-  
-  /**
-   * Navega al detalle de la orden relacionada a una asignación de dispositivo
-   * @param orderId ID de la orden a la que se desea navegar
-   * @returns void
-   */
+
   goDetailOrder(orderId: string): void {
     if (!orderId) return;
     this.router.navigate(['/app/orders/', orderId]);
   }
 
-  /**
-   * Navega a una página específica
-   * @param pageNumber Número de página a la que se quiere navegar
-   * @returns void
-   */
   goToPage(pageNumber: number): void {
-    const totalPages = this.getTotalPages();
-    if (pageNumber >= 1 && pageNumber <= totalPages) {
-      this.page = pageNumber;
+    if (pageNumber >= 1 && pageNumber <= this.totalPages()) {
+      this._page.set(pageNumber);
     }
   }
 
-  /**
-   * Navega a la página siguiente
-   * @returns void
-   */
-  nextPage(): void {
-    this.goToPage(this.page + 1);
-  }
+  nextPage(): void { this.goToPage(this.page + 1); }
+  previousPage(): void { this.goToPage(this.page - 1); }
 
-  /**
-   * Navega a la página anterior
-   * @returns void
-   */
-  previousPage(): void {
-    this.goToPage(this.page - 1);
-  }
-
-  /**
-   * Genera un array con los números de página para mostrar en el paginador
-   * @returns number[] Array con los números de página
-   */
-  get pages(): number[] {
-    const totalPages = this.getTotalPages();
-    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  private matchSearch(order: Order, search: string): boolean {
+    if (!search) return true;
+    return (
+      order.description.toLowerCase().includes(search) ||
+      order.assigneeType.toLowerCase().includes(search) ||
+      order.state.toLowerCase().includes(search)
+    );
   }
 }

--- a/src/app/modules/private/orders/resolvers/orders-resolver.ts
+++ b/src/app/modules/private/orders/resolvers/orders-resolver.ts
@@ -1,50 +1,7 @@
-import { Injectable } from '@angular/core';
-import { Resolve } from '@angular/router';
-import { Observable, forkJoin, of } from 'rxjs';
-import { catchError, concatMap, map } from 'rxjs/operators';
-import { Order } from '../models/Orders';
-import { OrdersService } from '../services/orders.service';
-import { EmployeesService } from '../../employees/services/employees.service';
-import { GroupsService } from '../../groups/services/groups.service';
+import { inject } from '@angular/core';
+import { ResolveFn } from '@angular/router';
+import { map } from 'rxjs';
+import { OrdersStore } from '../store/orders.store';
 
-@Injectable({ providedIn: 'root' })
-export class OrdersResolver implements Resolve<Order[] | 'ERROR'> {
-  constructor(
-    private ordersService: OrdersService,
-    private employeesService: EmployeesService,
-    private groupsService: GroupsService,
-  ) {}
-
-  resolve(): Observable<Order[] | 'ERROR'> {
-    return this.ordersService.getAllOrders().pipe(
-      concatMap((orders) => {
-        if (!orders || orders.length === 0) {
-          return of([]);
-        }
-        const responsibleRequests = orders.map((order) =>
-          order.assigneeType === 'EMPLOYEE'
-            ? this.employeesService
-                .getEmployeeById(order.assigneeId)
-                .pipe(catchError(() => of(null)))
-            : order.assigneeType === 'GROUP'
-              ? this.groupsService
-                  .getGroupById(order.assigneeId)
-                  .pipe(catchError(() => of(null)))
-              : of(null),
-        );
-        return forkJoin(responsibleRequests).pipe(
-          map((responsibles) =>
-            orders.map((order, i) => ({
-              ...order,
-              assignee: responsibles[i],
-            })),
-          ),
-        );
-      }),
-      catchError((err) => {
-        console.error('Error al cargar las órdenes:', err);
-        return of('ERROR' as const);
-      }),
-    );
-  }
-}
+export const ordersResolver: ResolveFn<boolean> = () =>
+  inject(OrdersStore).loadOrders().pipe(map(() => true));

--- a/src/app/modules/private/orders/services/orders.service.spec.ts
+++ b/src/app/modules/private/orders/services/orders.service.spec.ts
@@ -1,8 +1,10 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 import { OrdersService } from './orders.service';
 import { ApiService } from '../../../../core/services/api.service';
-import { Order, CreateOrderRequest } from '../models/Orders';
+import { Order, CreateOrderRequest, OrderStates } from '../models/Orders';
+import { DeviceStatus } from '../../devices/models/device.model';
 
 describe('OrdersService', () => {
   let service: OrdersService;
@@ -12,22 +14,27 @@ describe('OrdersService', () => {
   const mockOrder: Order = {
     id: '40ac7910-08be-44f6-ada4-60a06d8f6a18',
     description: 'Instalación de equipos a entregar banco davivienda',
-    state: 'FINISHED',
+    state: OrderStates.FINISHED,
     assigneeType: 'GROUP',
     assigneeId: '92bb39d7-8ad1-4343-98ce-db390189ca8a',
     createdAt: '2026-02-06T20:27:41.603963',
     updatedAt: '2026-02-06T20:36:40.943203',
+    assignee: null,
     items: [
-      { deviceId: '7944b840-42f1-47f0-b00f-c3c3b616d7a7', originalDeviceState: 'GOOD_CONDITION' },
-      { deviceId: 'a04bb10b-4f20-43e8-a0cf-7996a43934d2', originalDeviceState: 'GOOD_CONDITION' },
-      { deviceId: '10d62e30-aeb8-4d9a-9a71-c0e7911ca5d3', originalDeviceState: 'GOOD_CONDITION' }
-    ]
+      { deviceId: '7944b840-42f1-47f0-b00f-c3c3b616d7a7', originalDeviceState: DeviceStatus.GOOD_CONDITION },
+      { deviceId: 'a04bb10b-4f20-43e8-a0cf-7996a43934d2', originalDeviceState: DeviceStatus.GOOD_CONDITION },
+      { deviceId: '10d62e30-aeb8-4d9a-9a71-c0e7911ca5d3', originalDeviceState: DeviceStatus.GOOD_CONDITION },
+    ],
   };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
-      providers: [OrdersService, ApiService]
+      providers: [
+        OrdersService,
+        ApiService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
     });
 
     service = TestBed.inject(OrdersService);
@@ -43,6 +50,7 @@ describe('OrdersService', () => {
     expect(service).toBeTruthy();
   });
 
+  // ── createOrder ───────────────────────────────────────────────────────────
   describe('createOrder', () => {
     it('debe crear una orden exitosamente', (done) => {
       const createRequest: Partial<CreateOrderRequest> = {
@@ -51,8 +59,8 @@ describe('OrdersService', () => {
         assigneeId: '123e4567-e89b-12d3-a456-426614174000',
         devicesIds: [
           '7944b840-42f1-47f0-b00f-c3c3b616d7a7',
-          'a04bb10b-4f20-43e8-a0cf-7996a43934d2'
-        ]
+          'a04bb10b-4f20-43e8-a0cf-7996a43934d2',
+        ],
       };
 
       service.createOrder(createRequest).subscribe({
@@ -62,12 +70,10 @@ describe('OrdersService', () => {
           expect(order.items.length).toBe(3);
           done();
         },
-        error: (error) => {
-          done.fail(error);
-        }
+        error: done.fail,
       });
 
-      const req = httpMock.expectOne(request => request.url.includes('/orders'));
+      const req = httpMock.expectOne((r) => r.url.includes('/orders'));
       expect(req.request.method).toBe('POST');
       expect(req.request.body).toEqual(createRequest);
       req.flush(mockOrder);
@@ -78,46 +84,37 @@ describe('OrdersService', () => {
         description: 'Orden inválida',
         assigneeType: 'INVALID',
         assigneeId: 'invalid-id',
-        devicesIds: []
+        devicesIds: [],
       };
 
-      const errorMessage = 'Error al crear la orden';
-
       service.createOrder(createRequest).subscribe({
-        next: () => {
-          done.fail('Debería haber fallado');
-        },
+        next: () => done.fail('Debería haber fallado'),
         error: (error) => {
           expect(error.status).toBe(400);
-          expect(error.error).toBe(errorMessage);
           done();
-        }
+        },
       });
 
-      const req = httpMock.expectOne(request => request.url.includes('/orders'));
-      req.flush(errorMessage, { status: 400, statusText: 'Bad Request' });
+      const req = httpMock.expectOne((r) => r.url.includes('/orders'));
+      req.flush('Error al crear la orden', { status: 400, statusText: 'Bad Request' });
     });
   });
 
+  // ── getAllOrders ───────────────────────────────────────────────────────────
   describe('getAllOrders', () => {
     it('debe obtener todas las órdenes', (done) => {
-      const mockOrders: Order[] = [mockOrder];
-
       service.getAllOrders().subscribe({
         next: (orders) => {
           expect(orders.length).toBe(1);
           expect(orders[0]).toEqual(mockOrder);
-          expect(orders[0].id).toBe('40ac7910-08be-44f6-ada4-60a06d8f6a18');
           done();
         },
-        error: (error) => {
-          done.fail(error);
-        }
+        error: done.fail,
       });
 
-      const req = httpMock.expectOne(request => request.url.includes('/orders'));
+      const req = httpMock.expectOne((r) => r.url.includes('/orders'));
       expect(req.request.method).toBe('GET');
-      req.flush(mockOrders);
+      req.flush([mockOrder]);
     });
 
     it('debe retornar un array vacío cuando no hay órdenes', (done) => {
@@ -127,31 +124,28 @@ describe('OrdersService', () => {
           expect(orders).toEqual([]);
           done();
         },
-        error: (error) => {
-          done.fail(error);
-        }
+        error: done.fail,
       });
 
-      const req = httpMock.expectOne(request => request.url.includes('/orders'));
+      const req = httpMock.expectOne((r) => r.url.includes('/orders'));
       req.flush([]);
     });
 
     it('debe manejar errores al obtener órdenes', (done) => {
       service.getAllOrders().subscribe({
-        next: () => {
-          done.fail('Debería haber fallado');
-        },
+        next: () => done.fail('Debería haber fallado'),
         error: (error) => {
           expect(error.status).toBe(500);
           done();
-        }
+        },
       });
 
-      const req = httpMock.expectOne(request => request.url.includes('/orders'));
+      const req = httpMock.expectOne((r) => r.url.includes('/orders'));
       req.flush('Server Error', { status: 500, statusText: 'Internal Server Error' });
     });
   });
 
+  // ── getOrderById ──────────────────────────────────────────────────────────
   describe('getOrderById', () => {
     it('debe obtener una orden por ID', (done) => {
       const orderId = '40ac7910-08be-44f6-ada4-60a06d8f6a18';
@@ -163,14 +157,10 @@ describe('OrdersService', () => {
           expect(order.items.length).toBe(3);
           done();
         },
-        error: (error) => {
-          done.fail(error);
-        }
+        error: done.fail,
       });
 
-      const req = httpMock.expectOne(request =>
-        request.url.includes(`/orders/${orderId}`)
-      );
+      const req = httpMock.expectOne((r) => r.url.includes(`/orders/${orderId}`));
       expect(req.request.method).toBe('GET');
       req.flush(mockOrder);
     });
@@ -179,145 +169,152 @@ describe('OrdersService', () => {
       const orderId = 'non-existent-id';
 
       service.getOrderById(orderId).subscribe({
-        next: () => {
-          done.fail('Debería haber fallado');
-        },
+        next: () => done.fail('Debería haber fallado'),
         error: (error) => {
           expect(error.status).toBe(404);
           done();
-        }
+        },
       });
 
-      const req = httpMock.expectOne(request =>
-        request.url.includes(`/orders/${orderId}`)
-      );
+      const req = httpMock.expectOne((r) => r.url.includes(`/orders/${orderId}`));
       req.flush('Order not found', { status: 404, statusText: 'Not Found' });
     });
   });
 
+  // ── updateOrderState ──────────────────────────────────────────────────────
   describe('updateOrderState', () => {
     it('debe actualizar el estado de una orden usando FormData', (done) => {
       const orderId = '40ac7910-08be-44f6-ada4-60a06d8f6a18';
-      const newState = 'IN_PROGRESS';
-      const updatedOrder = { ...mockOrder, state: 'IN_PROGRESS' as const };
+      const newState = OrderStates.IN_PROCESS;
+      const updatedOrder: Order = { ...mockOrder, state: OrderStates.IN_PROCESS };
 
       service.updateOrderState(orderId, newState).subscribe({
         next: (order) => {
-          expect(order.state).toBe('IN_PROGRESS');
+          expect(order.state).toBe(OrderStates.IN_PROCESS);
           expect(order.id).toBe(orderId);
           done();
         },
-        error: (error) => {
-          done.fail(error);
-        }
+        error: done.fail,
       });
 
-      const req = httpMock.expectOne(request =>
-        request.url.includes(`/orders/${orderId}/state`)
-      );
-
+      const req = httpMock.expectOne((r) => r.url.includes(`/orders/${orderId}/state`));
       expect(req.request.method).toBe('PUT');
       expect(req.request.body instanceof FormData).toBe(true);
-
-      const formData = req.request.body as FormData;
-      expect(formData.get('newState')).toBe(newState);
-
+      expect((req.request.body as FormData).get('newState')).toBe(newState);
       req.flush(updatedOrder);
     });
 
     it('debe actualizar el estado a CREATED', (done) => {
       const orderId = '40ac7910-08be-44f6-ada4-60a06d8f6a18';
-      const newState = 'CREATED';
-      const updatedOrder = { ...mockOrder, state: 'CREATED' as const };
+      const updatedOrder: Order = { ...mockOrder, state: OrderStates.CREATED };
 
-      service.updateOrderState(orderId, newState).subscribe({
+      service.updateOrderState(orderId, OrderStates.CREATED).subscribe({
         next: (order) => {
-          expect(order.state).toBe('CREATED');
+          expect(order.state).toBe(OrderStates.CREATED);
           done();
         },
-        error: (error) => {
-          done.fail(error);
-        }
+        error: done.fail,
       });
 
-      const req = httpMock.expectOne(request =>
-        request.url.includes(`/orders/${orderId}/state`)
-      );
-
-      const formData = req.request.body as FormData;
-      expect(formData.get('newState')).toBe('CREATED');
-
+      const req = httpMock.expectOne((r) => r.url.includes(`/orders/${orderId}/state`));
+      expect((req.request.body as FormData).get('newState')).toBe(OrderStates.CREATED);
       req.flush(updatedOrder);
     });
 
-    it('debe actualizar el estado a DESPATCHED', (done) => {
+    it('debe actualizar el estado a DISPATCHED', (done) => {
       const orderId = '40ac7910-08be-44f6-ada4-60a06d8f6a18';
-      const newState = 'DESPATCHED';
-      const updatedOrder = { ...mockOrder, state: 'DESPATCHED' as const };
+      const updatedOrder: Order = { ...mockOrder, state: OrderStates.DISPATCHED };
 
-      service.updateOrderState(orderId, newState).subscribe({
+      service.updateOrderState(orderId, OrderStates.DISPATCHED).subscribe({
         next: (order) => {
-          expect(order.state).toBe('DESPATCHED');
+          expect(order.state).toBe(OrderStates.DISPATCHED);
           done();
         },
-        error: (error) => {
-          done.fail(error);
-        }
+        error: done.fail,
       });
 
-      const req = httpMock.expectOne(request =>
-        request.url.includes(`/orders/${orderId}/state`)
-      );
-
-      const formData = req.request.body as FormData;
-      expect(formData.get('newState')).toBe('DESPATCHED');
-
+      const req = httpMock.expectOne((r) => r.url.includes(`/orders/${orderId}/state`));
+      expect((req.request.body as FormData).get('newState')).toBe(OrderStates.DISPATCHED);
       req.flush(updatedOrder);
     });
 
     it('debe manejar errores al actualizar el estado', (done) => {
       const orderId = '40ac7910-08be-44f6-ada4-60a06d8f6a18';
-      const newState = 'INVALID_STATE';
 
-      service.updateOrderState(orderId, newState).subscribe({
-        next: () => {
-          done.fail('Debería haber fallado');
-        },
+      service.updateOrderState(orderId, 'INVALID_STATE').subscribe({
+        next: () => done.fail('Debería haber fallado'),
         error: (error) => {
           expect(error.status).toBe(400);
           done();
-        }
+        },
       });
 
-      const req = httpMock.expectOne(request =>
-        request.url.includes(`/orders/${orderId}/state`)
-      );
+      const req = httpMock.expectOne((r) => r.url.includes(`/orders/${orderId}/state`));
       req.flush('Invalid state', { status: 400, statusText: 'Bad Request' });
     });
 
-    it('debe manejar error 404 cuando la orden no existe', (done) => {
+    it('debe manejar error 404 cuando la orden no existe al actualizar estado', (done) => {
       const orderId = 'non-existent-id';
-      const newState = 'IN_PROGRESS';
 
-      service.updateOrderState(orderId, newState).subscribe({
-        next: () => {
-          done.fail('Debería haber fallado');
-        },
+      service.updateOrderState(orderId, OrderStates.IN_PROCESS).subscribe({
+        next: () => done.fail('Debería haber fallado'),
         error: (error) => {
           expect(error.status).toBe(404);
           done();
-        }
+        },
       });
 
-      const req = httpMock.expectOne(request =>
-        request.url.includes(`/orders/${orderId}/state`)
-      );
+      const req = httpMock.expectOne((r) => r.url.includes(`/orders/${orderId}/state`));
       req.flush('Order not found', { status: 404, statusText: 'Not Found' });
     });
   });
 
+  // ── updateOrder ───────────────────────────────────────────────────────────
+  describe('updateOrder', () => {
+    it('debe actualizar una orden exitosamente', (done) => {
+      const orderId = '40ac7910-08be-44f6-ada4-60a06d8f6a18';
+      const updateRequest: Partial<CreateOrderRequest> = {
+        description: 'Descripción actualizada',
+        assigneeType: 'EMPLOYEE',
+        assigneeId: 'emp-123',
+        devicesIds: ['dev-1'],
+      };
+      const updatedOrder: Order = { ...mockOrder, description: 'Descripción actualizada' };
+
+      service.updateOrder(orderId, updateRequest).subscribe({
+        next: (order) => {
+          expect(order.description).toBe('Descripción actualizada');
+          expect(order.id).toBe(orderId);
+          done();
+        },
+        error: done.fail,
+      });
+
+      const req = httpMock.expectOne((r) => r.url.includes(`/orders/update/${orderId}`));
+      expect(req.request.method).toBe('PUT');
+      expect(req.request.body).toEqual(updateRequest);
+      req.flush(updatedOrder);
+    });
+
+    it('debe manejar error al actualizar una orden inexistente', (done) => {
+      const orderId = 'non-existent-id';
+
+      service.updateOrder(orderId, { description: 'Test' }).subscribe({
+        next: () => done.fail('Debería haber fallado'),
+        error: (error) => {
+          expect(error.status).toBe(404);
+          done();
+        },
+      });
+
+      const req = httpMock.expectOne((r) => r.url.includes(`/orders/update/${orderId}`));
+      req.flush('Not found', { status: 404, statusText: 'Not Found' });
+    });
+  });
+
+  // ── Integración con ApiService ────────────────────────────────────────────
   describe('Integración con ApiService', () => {
-    it('debe usar ApiService para las peticiones', (done) => {
+    it('debe usar ApiService.get para obtener todas las órdenes', (done) => {
       const spy = spyOn(apiService, 'get').and.callThrough();
 
       service.getAllOrders().subscribe({
@@ -325,12 +322,10 @@ describe('OrdersService', () => {
           expect(spy).toHaveBeenCalledWith('/orders');
           done();
         },
-        error: (error) => {
-          done.fail(error);
-        }
+        error: done.fail,
       });
 
-      const req = httpMock.expectOne(request => request.url.includes('/orders'));
+      const req = httpMock.expectOne((r) => r.url.includes('/orders'));
       req.flush([]);
     });
 
@@ -340,7 +335,7 @@ describe('OrdersService', () => {
         description: 'Test',
         assigneeType: 'GROUP',
         assigneeId: 'test-id',
-        devicesIds: []
+        devicesIds: [],
       };
 
       service.createOrder(createRequest).subscribe({
@@ -348,51 +343,62 @@ describe('OrdersService', () => {
           expect(spy).toHaveBeenCalledWith('/orders', createRequest);
           done();
         },
-        error: (error) => {
-          done.fail(error);
-        }
+        error: done.fail,
       });
 
-      const req = httpMock.expectOne(request => request.url.includes('/orders'));
+      const req = httpMock.expectOne((r) => r.url.includes('/orders'));
       req.flush(mockOrder);
     });
 
     it('debe usar ApiService.putFormData para actualizar estado', (done) => {
       const spy = spyOn(apiService, 'putFormData').and.callThrough();
       const orderId = '40ac7910-08be-44f6-ada4-60a06d8f6a18';
-      const newState = 'IN_PROGRESS';
 
-      service.updateOrderState(orderId, newState).subscribe({
+      service.updateOrderState(orderId, OrderStates.IN_PROCESS).subscribe({
         next: () => {
           expect(spy).toHaveBeenCalled();
-          const callArgs = spy.calls.mostRecent().args;
-          expect(callArgs[0]).toBe(`/orders/${orderId}/state`);
-          expect(callArgs[1] instanceof FormData).toBe(true);
+          const [url, body] = spy.calls.mostRecent().args;
+          expect(url).toBe(`/orders/${orderId}/state`);
+          expect(body instanceof FormData).toBe(true);
           done();
         },
-        error: (error) => {
-          done.fail(error);
-        }
+        error: done.fail,
       });
 
-      const req = httpMock.expectOne(request =>
-        request.url.includes(`/orders/${orderId}/state`)
-      );
+      const req = httpMock.expectOne((r) => r.url.includes(`/orders/${orderId}/state`));
+      req.flush(mockOrder);
+    });
+
+    it('debe usar ApiService.put para actualizar una orden', (done) => {
+      const spy = spyOn(apiService, 'put').and.callThrough();
+      const orderId = '40ac7910-08be-44f6-ada4-60a06d8f6a18';
+      const updateRequest: Partial<CreateOrderRequest> = { description: 'Actualizada' };
+
+      service.updateOrder(orderId, updateRequest).subscribe({
+        next: () => {
+          expect(spy).toHaveBeenCalledWith(`/orders/update/${orderId}`, updateRequest);
+          done();
+        },
+        error: done.fail,
+      });
+
+      const req = httpMock.expectOne((r) => r.url.includes(`/orders/update/${orderId}`));
       req.flush(mockOrder);
     });
   });
 
+  // ── Casos Edge ────────────────────────────────────────────────────────────
   describe('Casos Edge', () => {
-    it('debe manejar órdenes con múltiples dispositivos', (done) => {
+    it('debe manejar órdenes con múltiples dispositivos de distintos estados', (done) => {
       const orderWithManyDevices: Order = {
         ...mockOrder,
         items: [
-          { deviceId: 'device-1', originalDeviceState: 'GOOD_CONDITION' },
-          { deviceId: 'device-2', originalDeviceState: 'FAIR' },
-          { deviceId: 'device-3', originalDeviceState: 'NEEDS_REPAIR' },
-          { deviceId: 'device-4', originalDeviceState: 'OCCUPIED' },
-          { deviceId: 'device-5', originalDeviceState: 'GOOD_CONDITION' }
-        ]
+          { deviceId: 'device-1', originalDeviceState: DeviceStatus.GOOD_CONDITION },
+          { deviceId: 'device-2', originalDeviceState: DeviceStatus.FAIR },
+          { deviceId: 'device-3', originalDeviceState: DeviceStatus.NEEDS_REPAIR },
+          { deviceId: 'device-4', originalDeviceState: DeviceStatus.OCCUPIED },
+          { deviceId: 'device-5', originalDeviceState: DeviceStatus.GOOD_CONDITION },
+        ],
       };
 
       service.getOrderById(mockOrder.id).subscribe({
@@ -400,60 +406,54 @@ describe('OrdersService', () => {
           expect(order.items.length).toBe(5);
           done();
         },
-        error: (error) => {
-          done.fail(error);
-        }
+        error: done.fail,
       });
 
-      const req = httpMock.expectOne(request =>
-        request.url.includes(`/orders/${mockOrder.id}`)
-      );
+      const req = httpMock.expectOne((r) => r.url.includes(`/orders/${mockOrder.id}`));
       req.flush(orderWithManyDevices);
     });
 
     it('debe manejar órdenes sin dispositivos', (done) => {
-      const orderWithoutDevices: Order = {
-        ...mockOrder,
-        items: []
-      };
+      const orderWithoutDevices: Order = { ...mockOrder, items: [] };
 
       service.getOrderById(mockOrder.id).subscribe({
         next: (order) => {
           expect(order.items.length).toBe(0);
           done();
         },
-        error: (error) => {
-          done.fail(error);
-        }
+        error: done.fail,
       });
 
-      const req = httpMock.expectOne(request =>
-        request.url.includes(`/orders/${mockOrder.id}`)
-      );
+      const req = httpMock.expectOne((r) => r.url.includes(`/orders/${mockOrder.id}`));
       req.flush(orderWithoutDevices);
     });
 
     it('debe manejar órdenes con descripción larga', (done) => {
-      const orderWithLongDescription: Order = {
-        ...mockOrder,
-        description: 'A'.repeat(500)
-      };
+      const orderWithLongDescription: Order = { ...mockOrder, description: 'A'.repeat(500) };
 
       service.getOrderById(mockOrder.id).subscribe({
         next: (order) => {
           expect(order.description.length).toBe(500);
           done();
         },
-        error: (error) => {
-          done.fail(error);
-        }
+        error: done.fail,
       });
 
-      const req = httpMock.expectOne(request =>
-        request.url.includes(`/orders/${mockOrder.id}`)
-      );
+      const req = httpMock.expectOne((r) => r.url.includes(`/orders/${mockOrder.id}`));
       req.flush(orderWithLongDescription);
     });
+
+    it('debe manejar errores de red (status 0)', (done) => {
+      service.getAllOrders().subscribe({
+        next: () => done.fail('Debería haber fallado'),
+        error: (error) => {
+          expect(error.status).toBe(0);
+          done();
+        },
+      });
+
+      const req = httpMock.expectOne((r) => r.url.includes('/orders'));
+      req.flush(null, { status: 0, statusText: 'Network Error' });
+    });
   });
-  
 });

--- a/src/app/modules/private/orders/services/orders.service.ts
+++ b/src/app/modules/private/orders/services/orders.service.ts
@@ -3,6 +3,11 @@ import { ApiService } from '../../../../core/services/api.service';
 import {CreateOrderRequest, Order} from '../models/Orders';
 import { Observable } from 'rxjs';
 
+/**
+ * Servicio para gestionar las operaciones relacionadas con las órdenes, incluyendo la creación, obtención y actualización de órdenes. Utiliza ApiService para comunicarse con el backend y proporciona métodos específicos para cada operación.
+ * @since 2026-05-11
+ * @author BunnyString
+ */
 @Injectable({
   providedIn: 'root'
 })

--- a/src/app/modules/private/orders/store/orders.store.ts
+++ b/src/app/modules/private/orders/store/orders.store.ts
@@ -1,0 +1,107 @@
+import { computed, inject } from '@angular/core';
+import {
+  patchState,
+  signalStore,
+  withComputed,
+  withMethods,
+  withState,
+} from '@ngrx/signals';
+import {
+  Observable,
+  catchError,
+  concatMap,
+  forkJoin,
+  map,
+  of,
+  tap,
+} from 'rxjs';
+import { Order, OrderStates, OrdersState } from '../models/Orders';
+import { OrdersService } from '../services/orders.service';
+import { EmployeesService } from '../../employees/services/employees.service';
+import { GroupsService } from '../../groups/services/groups.service';
+
+
+/**
+ * Store para gestionar el estado de las órdenes, incluyendo la carga, actualización y eliminación de órdenes, así como el manejo de errores y estados de carga.
+ * @since 2026-05-11
+ * @author BunnyString
+ */
+export const OrdersStore = signalStore(
+  { providedIn: 'root' },
+  withState<OrdersState>({
+    orders: [],
+    isLoading: false,
+    error: null,
+  }),
+  withComputed(({ orders }) => ({
+    stats: computed(() => {
+      const list = orders();
+      return {
+        totalOrders: list.length,
+        created: list.filter((o) => o.state === OrderStates.CREATED).length,
+        inProcess: list.filter((o) => o.state === OrderStates.IN_PROCESS).length,
+        dispatched: list.filter((o) => o.state === OrderStates.DISPATCHED).length,
+        finished: list.filter((o) => o.state === OrderStates.FINISHED).length,
+      };
+    }),
+  })),
+  withMethods((store) => {
+    const ordersService = inject(OrdersService);
+    const employeesService = inject(EmployeesService);
+    const groupsService = inject(GroupsService);
+
+    return {
+      loadOrders(): Observable<Order[]> {
+        patchState(store, { isLoading: true, error: null });
+        return ordersService.getAllOrders().pipe(
+          concatMap((orders) => {
+            if (!orders || orders.length === 0) return of([]);
+            const responsibleRequests = orders.map((order) =>
+              order.assigneeType === 'EMPLOYEE'
+                ? employeesService
+                    .getEmployeeById(order.assigneeId)
+                    .pipe(catchError(() => of(null)))
+                : order.assigneeType === 'GROUP'
+                  ? groupsService
+                      .getGroupById(order.assigneeId)
+                      .pipe(catchError(() => of(null)))
+                  : of(null),
+            );
+            return forkJoin(responsibleRequests).pipe(
+              map((responsibles) =>
+                orders.map((order, i) => ({
+                  ...order,
+                  assignee: responsibles[i],
+                })),
+              ),
+            );
+          }),
+          tap((orders) => patchState(store, { orders, isLoading: false })),
+          catchError((err) => {
+            console.error('Error al cargar órdenes:', err);
+            patchState(store, { error: 'Error al cargar órdenes', isLoading: false });
+            return of([]);
+          }),
+        );
+      },
+
+      upsertOrder(order: Order): void {
+        patchState(store, (state) => ({
+          orders: state.orders.some((o) => o.id === order.id)
+            ? state.orders.map((o) => (o.id === order.id ? order : o))
+            : [...state.orders, order],
+        }));
+      },
+
+      removeOrder(id: string): void {
+        patchState(store, (state) => ({
+          orders: state.orders.filter((o) => o.id !== id),
+        }));
+      },
+
+      clearError(): void {
+        patchState(store, { error: null });
+      },
+    };
+  }),
+);

--- a/src/app/modules/public/auth/login/login.component.spec.ts
+++ b/src/app/modules/public/auth/login/login.component.spec.ts
@@ -1,4 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { LoginComponent } from './login.component';
 
@@ -8,9 +11,13 @@ describe('LoginComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [LoginComponent]
-    })
-    .compileComponents();
+      imports: [LoginComponent],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(LoginComponent);
     component = fixture.componentInstance;

--- a/src/app/modules/public/auth/register/register.component.spec.ts
+++ b/src/app/modules/public/auth/register/register.component.spec.ts
@@ -1,4 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { RegisterComponent } from './register.component';
 
@@ -8,9 +11,13 @@ describe('RegisterComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RegisterComponent]
-    })
-    .compileComponents();
+      imports: [RegisterComponent],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(RegisterComponent);
     component = fixture.componentInstance;

--- a/src/app/shared/animated-pet/animated-pet.component.spec.ts
+++ b/src/app/shared/animated-pet/animated-pet.component.spec.ts
@@ -1,8 +1,4 @@
-/* tslint:disable:no-unused-variable */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
-
 import { AnimatedPetComponent } from './animated-pet.component';
 
 describe('AnimatedPetComponent', () => {
@@ -10,13 +6,10 @@ describe('AnimatedPetComponent', () => {
   let fixture: ComponentFixture<AnimatedPetComponent>;
 
   beforeEach(async () => {
-    TestBed.configureTestingModule({
-      declarations: [ AnimatedPetComponent ]
-    })
-    .compileComponents();
-  });
+    await TestBed.configureTestingModule({
+      imports: [AnimatedPetComponent],
+    }).compileComponents();
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(AnimatedPetComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,9 @@
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictTemplates": true
-  }
+  },
+  "exclude": [
+    "node_modules",
+    "**/*.spec.ts"
+  ]
 }

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -8,6 +8,9 @@
       "jasmine"
     ]
   },
+  "exclude": [
+    "node_modules"
+  ],
   "include": [
     "src/**/*.spec.ts",
     "src/**/*.d.ts"


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción
Se refactoriza el módulo de **órdenes** para modernizar la gestión de estado, simplificar la resolución de datos y fortalecer la cobertura de pruebas del proyecto tras la migración a Angular 21.

Los cambios principales incluyen:
- creación de `OrdersStore` usando **@ngrx/signals**
  - estado local para `orders`, `isLoading` y `error`
  - métodos para cargar, actualizar y eliminar órdenes
  - estadísticas derivadas con `computed`
- simplificación del resolver de órdenes
  - reemplazo del resolver basado en servicios por un `ResolveFn`
  - delegación de la carga inicial al `OrdersStore`
- refactor de `orders.component.ts` y `orders.component.html`
  - integración con `OrdersStore`
  - actualización del flujo de filtros, paginación y manejo de errores
  - ajuste del renderizado y comportamiento del listado
- limpieza de `orders-detail.component.ts`
  - eliminación de `console.log` de depuración
- ampliación significativa de pruebas unitarias:
  - `orders-detail.component.spec.ts`
  - `orders.component.spec.ts`
  - `orders.service.spec.ts`
  - ajustes en specs de `login`, `register` y `animated-pet`
- actualización de configuración de TypeScript para separar correctamente compilación de app y specs:
  - exclusión de `**/*.spec.ts` en `tsconfig.json`
  - inclusión explícita de specs en `tsconfig.spec.json`

## ¿Qué tipo de cambio es?
- [ ] Bugfix 🐞
- [x] Feature ✨
- [x] Refactor 🔧
- [ ] Documentación 📚
- [x] Otro

## ¿Cómo probar estos cambios?
1. Instalar dependencias:
   ```bash
   npm install
   ```

2. Verificar compilación de la aplicación:
   ```bash
   npm exec -- ng build
   ```

3. Ejecutar pruebas unitarias:
   ```bash
   npm test
   ```

4. Levantar la aplicación:
   ```bash
   npm start
   ```

5. Validar manualmente el módulo de órdenes:
   - ingresar al listado de órdenes
   - verificar carga inicial de datos
   - validar filtros por texto y estado
   - comprobar paginación
   - abrir detalle de una orden
   - refrescar detalle de orden
   - navegar desde una orden hacia su asignado (empleado o grupo)
   - validar estados vacíos y de error

6. Verificar específicamente el listado de órdenes:
   - que muestre toast informativo si no hay órdenes
   - que muestre toast de error si falla la carga
   - que el filtrado actualice resultados correctamente
   - que la paginación funcione con distintas cantidades de registros
   - que los modales se abran/cierren correctamente si aplica

7. Verificar específicamente el detalle de orden:
   - que cargue la orden por `id` desde la ruta
   - que resuelva correctamente el asignado
   - que muestre estados de dispositivos y de orden correctamente
   - que el botón volver funcione
   - que no existan errores por rutas a empleados o grupos

8. Validar configuración de tests:
   - que `ng build` no intente compilar archivos `*.spec.ts`
   - que `ng test` siga detectando y ejecutando specs normalmente

## Checklist
- [x] El código compila y pasa los tests
- [ ] La documentación está actualizada (si aplica)
- [x] No hay warnings nuevos
- [x] Revisé el formato y convenciones de código

## Screenshots (si aplica)
No aplica.

## Issue relacionada
<!-- Si hay issues asociadas, referencia: closes #123 -->

## Notas para el revisor
- El cambio estructural más importante es la introducción de `OrdersStore` con señales para centralizar la gestión de estado del módulo.
- El resolver de órdenes fue simplificado para delegar la carga al store, lo que reduce lógica duplicada en la capa de routing.
- También se fortaleció bastante la base de pruebas unitarias del módulo de órdenes.
- Se ajustó la configuración TypeScript para evitar que la compilación principal procese archivos de test.
- Puntos de revisión sugeridos:
  - consistencia entre `OrdersStore`, resolver y componentes
  - manejo de errores y carga inicial
  - navegación a empleados/grupos desde órdenes
  - impacto del cambio en specs y configuración de testing