### PR TITLE
Merge Main to Dev

### DIFF
--- a/src/app/modules/private/employees/employees.routes.ts
+++ b/src/app/modules/private/employees/employees.routes.ts
@@ -1,4 +1,5 @@
 import { Routes } from '@angular/router';
+import { employeesResolver } from './resolvers/employees-resolver';
 
 /**
  * Rutas del módulo de empleados con lazy loading
@@ -11,6 +12,7 @@ export const EMPLOYEES_ROUTES: Routes = [
   {
     path: '',
     loadComponent: () => import('./pages/employees/employees.component').then(m => m.EmployeesComponent),
+    resolve: { employees: employeesResolver },
     data: {
       breadcrumb: 'Empleados',
       title: 'Gestión de Empleados',

--- a/src/app/modules/private/employees/pages/employees/employees.component.html
+++ b/src/app/modules/private/employees/pages/employees/employees.component.html
@@ -8,7 +8,7 @@
 }
 
 <div class="container mx-auto px-4 py-6">
-  @if (!employeesResource.error()) {
+  @if (!store.error()) {
 
     <!-- HEADER -->
     <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-6 mb-8">
@@ -93,7 +93,7 @@
         </svg>
         Limpiar
       </button>
-      <button class="btn btn-ghost gap-2 ml-auto" (click)="employeesResource.reload()" [disabled]="loading()">
+      <button class="btn btn-ghost gap-2 ml-auto" (click)="loadEmployees()" [disabled]="loading()">
         @if (loading()) {
           <span class="loading loading-spinner loading-xs"></span>
         } @else {
@@ -288,7 +288,7 @@
     }
 
     <!-- SIN DATOS -->
-    @if (stats.total === 0 && !employeesResource.isLoading()) {
+    @if (stats.total === 0 && !store.isLoading()) {
       <div class="py-16 text-center opacity-80">
         <svg class="mx-auto h-24 w-24 text-blue-200" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round"
@@ -317,7 +317,7 @@
       <p class="text-base-content/60 mb-6 max-w-md">
         Hubo un problema al conectar con el servidor. Por favor verifica tu conexión e intenta nuevamente.
       </p>
-      <button class="btn btn-primary gap-2" (click)="employeesResource.reload()" [disabled]="loading()">
+      <button class="btn btn-primary gap-2" (click)="loadEmployees()" [disabled]="loading()">
         @if (loading()) {
           <span class="loading loading-spinner loading-sm"></span>
         } @else {

--- a/src/app/modules/private/employees/pages/employees/employees.component.spec.ts
+++ b/src/app/modules/private/employees/pages/employees/employees.component.spec.ts
@@ -1,15 +1,199 @@
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { of } from 'rxjs';
 import { EmployeesComponent } from './employees.component';
+import { EmployeesStore } from '../../store/employees.store';
+import { EmployeesService } from '../../services/employees.service';
+import { Employee, EmployeeStatus } from '../../models/employe.model';
+
+const mockEmployees: Employee[] = [
+  { id: 'e1', fullName: 'Ana García', email: 'ana@empresa.com', documentType: 'CC', documentNumber: '111', status: EmployeeStatus.ACTIVE },
+  { id: 'e2', fullName: 'Luis Pérez', email: 'luis@empresa.com', documentType: 'CC', documentNumber: '222', status: EmployeeStatus.INACTIVE },
+  { id: 'e3', fullName: 'Marta López', email: 'marta@empresa.com', documentType: 'CE', documentNumber: '333', status: EmployeeStatus.ACTIVE },
+];
 
 describe('EmployeesComponent', () => {
+  let component: EmployeesComponent;
+  let fixture: ComponentFixture<EmployeesComponent>;
+  let employeesServiceSpy: jasmine.SpyObj<EmployeesService>;
+
   beforeEach(async () => {
+    employeesServiceSpy = jasmine.createSpyObj('EmployeesService', ['getAllEmployees']);
+    employeesServiceSpy.getAllEmployees.and.returnValue(of(mockEmployees));
+
     await TestBed.configureTestingModule({
       imports: [EmployeesComponent],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        EmployeesStore,
+        { provide: EmployeesService, useValue: employeesServiceSpy },
+      ],
     }).compileComponents();
+
+    const store = TestBed.inject(EmployeesStore);
+    await store.loadEmployees().toPromise();
+
+    fixture = TestBed.createComponent(EmployeesComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
   });
 
-  it('should create', () => {
-    const fixture = TestBed.createComponent(EmployeesComponent);
-    expect(fixture.componentInstance).toBeTruthy();
+  it('debe crear el componente', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('filteredEmployees()', () => {
+    it('debe devolver todos los empleados sin búsqueda activa', () => {
+      expect(component.filteredEmployees().length).toBe(3);
+    });
+
+    it('debe filtrar por nombre completo', () => {
+      component.search.set('ana');
+      expect(component.filteredEmployees().length).toBe(1);
+      expect(component.filteredEmployees()[0].fullName).toBe('Ana García');
+    });
+
+    it('debe filtrar por email', () => {
+      component.search.set('luis@empresa');
+      expect(component.filteredEmployees().length).toBe(1);
+      expect(component.filteredEmployees()[0].id).toBe('e2');
+    });
+
+    it('debe ser insensible a mayúsculas', () => {
+      component.search.set('MARTA');
+      expect(component.filteredEmployees().length).toBe(1);
+    });
+
+    it('debe devolver lista vacía sin coincidencias', () => {
+      component.search.set('zzznomatch');
+      expect(component.filteredEmployees().length).toBe(0);
+    });
+  });
+
+  describe('filteredStats()', () => {
+    it('debe calcular el total, activos e inactivos', () => {
+      const stats = component.filteredStats();
+      expect(stats.total).toBe(3);
+      expect(stats.active).toBe(2);
+      expect(stats.inactive).toBe(1);
+    });
+
+    it('debe recalcular al filtrar', () => {
+      component.search.set('ana');
+      const stats = component.filteredStats();
+      expect(stats.total).toBe(1);
+      expect(stats.active).toBe(1);
+      expect(stats.inactive).toBe(0);
+    });
+  });
+
+  describe('paginación', () => {
+    it('totalItems debe reflejar los empleados filtrados', () => {
+      expect(component.totalItems()).toBe(3);
+    });
+
+    it('pagedEmployees debe respetar el tamaño de página', () => {
+      component.pageSize.set(2);
+      expect(component.pagedEmployees().length).toBe(2);
+    });
+
+    it('goToPage debe actualizar la página actual', () => {
+      component.pageSize.set(2);
+      component.goToPage(2);
+      expect(component.page()).toBe(2);
+    });
+
+    it('nextPage no debe superar el total de páginas', () => {
+      component.pageSize.set(2);
+      component.goToPage(2);
+      component.nextPage();
+      expect(component.page()).toBe(2);
+    });
+
+    it('previousPage no debe bajar de página 1', () => {
+      component.previousPage();
+      expect(component.page()).toBe(1);
+    });
+
+    it('setPageSize debe resetear la página a 1', () => {
+      component.page.set(3);
+      component.setPageSize('20');
+      expect(component.pageSize()).toBe(20);
+      expect(component.page()).toBe(1);
+    });
+  });
+
+  describe('onSearchChange()', () => {
+    it('debe actualizar búsqueda y resetear página', () => {
+      component.page.set(2);
+      component.onSearchChange('marta');
+      expect(component.search()).toBe('marta');
+      expect(component.page()).toBe(1);
+    });
+  });
+
+  describe('resetFilters()', () => {
+    it('debe limpiar búsqueda y volver a página 1', () => {
+      component.search.set('test');
+      component.page.set(3);
+      component.resetFilters();
+      expect(component.search()).toBe('');
+      expect(component.page()).toBe(1);
+    });
+  });
+
+  describe('gestión de modales', () => {
+    it('openCreateModal debe activar showCreateModal', () => {
+      component.openCreateModal();
+      expect(component.showCreateModal()).toBeTrue();
+      expect(component.showEditModal()).toBeFalse();
+      expect(component.employeeToEdit()).toBeNull();
+    });
+
+    it('openEditModal debe activar showEditModal con el empleado', () => {
+      component.openEditModal(mockEmployees[0]);
+      expect(component.showEditModal()).toBeTrue();
+      expect(component.showCreateModal()).toBeFalse();
+      expect(component.employeeToEdit()).toEqual(mockEmployees[0]);
+    });
+
+    it('openDeleteModal debe activar showDeleteModal con el empleado', () => {
+      component.openDeleteModal(mockEmployees[1]);
+      expect(component.showDeleteModal()).toBeTrue();
+      expect(component.employeeToDelete()).toEqual(mockEmployees[1]);
+    });
+
+    it('closeModals debe cerrar todos los modales', () => {
+      component.openCreateModal();
+      component.closeModals();
+      expect(component.showCreateModal()).toBeFalse();
+      expect(component.showEditModal()).toBeFalse();
+      expect(component.showDeleteModal()).toBeFalse();
+      expect(component.employeeToEdit()).toBeNull();
+      expect(component.employeeToDelete()).toBeNull();
+    });
+
+    it('cancelDelete debe cerrar modal de eliminación', () => {
+      component.openDeleteModal(mockEmployees[0]);
+      component.cancelDelete();
+      expect(component.showDeleteModal()).toBeFalse();
+      expect(component.employeeToDelete()).toBeNull();
+    });
+  });
+
+  describe('getShortText()', () => {
+    it('debe truncar texto mayor a 35 caracteres', () => {
+      const result = component.getShortText('Este texto es demasiado largo para mostrarlo completo');
+      expect(result.length).toBeLessThanOrEqual(36);
+      expect(result.endsWith('…')).toBeTrue();
+    });
+
+    it('debe devolver texto corto sin modificar', () => {
+      expect(component.getShortText('Texto corto')).toBe('Texto corto');
+    });
   });
 });

--- a/src/app/modules/private/employees/pages/employees/employees.component.ts
+++ b/src/app/modules/private/employees/pages/employees/employees.component.ts
@@ -1,26 +1,25 @@
 import {
-  Component,
   ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  OnInit,
   computed,
-  effect,
   inject,
-  resource,
   signal,
 } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { toSignal, takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
-import { firstValueFrom } from 'rxjs';
 import { Employee, EmployeeFormResult, EmployeeStatus } from '../../models/employe.model';
 import { toast } from 'ngx-sonner';
 import { EmployeeCreateEditModalComponent } from '../../modals/employee-create-edit-modal/employee-create-edit-modal.component';
 import { EmployeeDeleteModalComponent } from '../../modals/employee-delete-modal/employee-delete-modal.component';
 import { LoadingService } from '../../../../../core/services/loading.service';
-import { EmployeesService } from '../../services/employees.service';
+import { EmployeesStore } from '../../store/employees.store';
 
 /**
  * Componente principal del módulo de empleados
  *
- * @since 2026-05-10
+ * @since 2026-05-13
  * @author Bunnystring
  */
 @Component({
@@ -31,42 +30,33 @@ import { EmployeesService } from '../../services/employees.service';
   templateUrl: './employees.component.html',
   styleUrl: './employees.component.css',
 })
-export class EmployeesComponent {
-  private readonly employeesService = inject(EmployeesService);
-  private readonly loadingService = inject(LoadingService);
+export class EmployeesComponent implements OnInit {
+  protected readonly store = inject(EmployeesStore);
   private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
 
   readonly EmployeeStatus = EmployeeStatus;
 
-  // Estado de carga del interceptor HTTP
-  readonly loading = toSignal(this.loadingService.loading$, { initialValue: false });
+  readonly loading = toSignal(inject(LoadingService).loading$, { initialValue: false });
 
-  // Recurso reactivo: carga empleados del servidor
-  readonly employeesResource = resource({
-    loader: () => firstValueFrom(this.employeesService.getAllEmployees()),
-  });
-
-  // Búsqueda y paginación
   readonly search = signal('');
   readonly page = signal(1);
   readonly pageSize = signal(10);
 
-  // Estado de modales
   readonly showCreateModal = signal(false);
   readonly showEditModal = signal(false);
   readonly showDeleteModal = signal(false);
   readonly employeeToEdit = signal<Employee | null>(null);
   readonly employeeToDelete = signal<Employee | null>(null);
 
-  // Estado derivado con computed()
   readonly filteredEmployees = computed(() => {
-    const employees = this.employeesResource.value() ?? [];
-    const search = this.search().toLowerCase();
-    if (!search) return employees;
+    const s = this.search().toLowerCase();
+    const employees = this.store.employees();
+    if (!s) return employees;
     return employees.filter(
       (e) =>
-        e.fullName.toLowerCase().includes(search) ||
-        e.email.toLowerCase().includes(search),
+        e.fullName.toLowerCase().includes(s) ||
+        e.email.toLowerCase().includes(s),
     );
   });
 
@@ -90,19 +80,18 @@ export class EmployeesComponent {
     return this.filteredEmployees().slice(start, start + this.pageSize());
   });
 
-  constructor() {
-    // Efectos de notificación (side effects sobre signals)
-    effect(() => {
-      if (this.employeesResource.error()) {
-        toast.error('Error al obtener empleados');
-      }
-    });
-    effect(() => {
-      const employees = this.employeesResource.value();
-      if (employees !== undefined && employees.length === 0) {
-        toast.info('No hay empleados para mostrar actualmente.');
-      }
-    });
+  get employeeError() { return !!this.store.error(); }
+
+  ngOnInit(): void {
+    if (this.store.error()) {
+      toast.error('No se pudo conectar al microservicio de empleados.');
+    } else if (this.store.employees().length === 0) {
+      toast.info('No hay empleados para mostrar actualmente.');
+    }
+  }
+
+  loadEmployees(): void {
+    this.store.loadEmployees().pipe(takeUntilDestroyed(this.destroyRef)).subscribe();
   }
 
   onSearchChange(value: string): void {
@@ -140,7 +129,7 @@ export class EmployeesComponent {
   onEmployeeDeleted(): void {
     this.showDeleteModal.set(false);
     this.employeeToDelete.set(null);
-    this.employeesResource.reload();
+    this.loadEmployees();
   }
 
   cancelDelete(): void {
@@ -158,8 +147,12 @@ export class EmployeesComponent {
 
   handleModalSave({ mode }: EmployeeFormResult): void {
     toast.success(mode === 'create' ? 'Empleado creado' : 'Empleado actualizado');
-    this.employeesResource.reload();
+    this.loadEmployees();
     this.closeModals();
+  }
+
+  clearError(): void {
+    this.store.clearError();
   }
 
   goToDetail(employee: Employee): void {

--- a/src/app/modules/private/employees/resolvers/employees-resolver.ts
+++ b/src/app/modules/private/employees/resolvers/employees-resolver.ts
@@ -1,0 +1,7 @@
+import { inject } from '@angular/core';
+import { ResolveFn } from '@angular/router';
+import { map } from 'rxjs';
+import { EmployeesStore } from '../store/employees.store';
+
+export const employeesResolver: ResolveFn<boolean> = () =>
+  inject(EmployeesStore).loadEmployees().pipe(map(() => true));

--- a/src/app/modules/private/employees/services/employees.service.spec.ts
+++ b/src/app/modules/private/employees/services/employees.service.spec.ts
@@ -1,15 +1,117 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { EmployeesService } from './employees.service';
+import { Employee, EmployeeStatus, CreateEmployeeRq } from '../models/employe.model';
+import { environment } from '../../../../../environments/environment';
+
+const BASE = environment.apiUrl;
+
+const mockEmployee: Employee = {
+  id: 'e1',
+  fullName: 'Ana García',
+  email: 'ana@mail.com',
+  documentType: 'CC',
+  documentNumber: '111222333',
+  status: EmployeeStatus.ACTIVE,
+};
 
 describe('EmployeesService', () => {
+  let service: EmployeesService;
+  let httpMock: HttpTestingController;
+
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [EmployeesService],
+      providers: [
+        EmployeesService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
     });
+
+    service = TestBed.inject(EmployeesService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('debe ser creado', () => {
-    const service = TestBed.inject(EmployeesService);
     expect(service).toBeTruthy();
+  });
+
+  describe('getAllEmployees()', () => {
+    it('debe hacer GET /employees y devolver lista', () => {
+      service.getAllEmployees().subscribe((employees) => {
+        expect(employees.length).toBe(1);
+        expect(employees[0].id).toBe('e1');
+      });
+
+      const req = httpMock.expectOne(`${BASE}/employees`);
+      expect(req.request.method).toBe('GET');
+      req.flush([mockEmployee]);
+    });
+  });
+
+  describe('getEmployeeById()', () => {
+    it('debe hacer GET /employees/:id y devolver el empleado', () => {
+      service.getEmployeeById('e1').subscribe((employee) => {
+        expect(employee.id).toBe('e1');
+        expect(employee.fullName).toBe('Ana García');
+      });
+
+      const req = httpMock.expectOne(`${BASE}/employees/e1`);
+      expect(req.request.method).toBe('GET');
+      req.flush(mockEmployee);
+    });
+  });
+
+  describe('createEmployee()', () => {
+    it('debe hacer POST /employees con los datos correctos', () => {
+      const payload: CreateEmployeeRq = {
+        fullName: 'Nuevo Empleado',
+        email: 'nuevo@mail.com',
+        documentType: 'CC',
+        documentNumber: '999888777',
+        status: EmployeeStatus.ACTIVE,
+      };
+
+      service.createEmployee(payload).subscribe((employee) => {
+        expect(employee.fullName).toBe('Nuevo Empleado');
+      });
+
+      const req = httpMock.expectOne(`${BASE}/employees`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(payload);
+      req.flush({ ...mockEmployee, ...payload, id: 'e2' });
+    });
+  });
+
+  describe('updateEmployee()', () => {
+    it('debe hacer PUT /employees/:id con los datos correctos', () => {
+      const payload: Partial<CreateEmployeeRq> = { fullName: 'Ana Modificada' };
+
+      service.updateEmployee('e1', payload).subscribe((employee) => {
+        expect(employee.fullName).toBe('Ana Modificada');
+      });
+
+      const req = httpMock.expectOne(`${BASE}/employees/e1`);
+      expect(req.request.method).toBe('PUT');
+      expect(req.request.body).toEqual(payload);
+      req.flush({ ...mockEmployee, fullName: 'Ana Modificada' });
+    });
+  });
+
+  describe('deleteEmployee()', () => {
+    it('debe hacer DELETE /employees/:id', () => {
+      service.deleteEmployee('e1').subscribe((res) => {
+        expect(res).toBeNull();
+      });
+
+      const req = httpMock.expectOne(`${BASE}/employees/e1`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null);
+    });
   });
 });

--- a/src/app/modules/private/employees/store/employees.store.spec.ts
+++ b/src/app/modules/private/employees/store/employees.store.spec.ts
@@ -1,0 +1,143 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { of, throwError } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
+import { EmployeesStore } from './employees.store';
+import { EmployeesService } from '../services/employees.service';
+import { Employee, EmployeeStatus } from '../models/employe.model';
+
+const mockEmployees: Employee[] = [
+  { id: 'e1', fullName: 'Ana García', email: 'ana@mail.com', documentType: 'CC', documentNumber: '111', status: EmployeeStatus.ACTIVE },
+  { id: 'e2', fullName: 'Luis Pérez', email: 'luis@mail.com', documentType: 'CC', documentNumber: '222', status: EmployeeStatus.INACTIVE },
+  { id: 'e3', fullName: 'Marta López', email: 'marta@mail.com', documentType: 'CE', documentNumber: '333', status: EmployeeStatus.ACTIVE },
+];
+
+describe('EmployeesStore', () => {
+  let store: InstanceType<typeof EmployeesStore>;
+  let employeesServiceSpy: jasmine.SpyObj<EmployeesService>;
+
+  beforeEach(() => {
+    employeesServiceSpy = jasmine.createSpyObj('EmployeesService', ['getAllEmployees']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        EmployeesStore,
+        { provide: EmployeesService, useValue: employeesServiceSpy },
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    store = TestBed.inject(EmployeesStore);
+  });
+
+  describe('Estado inicial', () => {
+    it('debe inicializar con lista vacía', () => {
+      expect(store.employees()).toEqual([]);
+    });
+
+    it('debe inicializar sin carga activa', () => {
+      expect(store.isLoading()).toBeFalse();
+    });
+
+    it('debe inicializar sin error', () => {
+      expect(store.error()).toBeNull();
+    });
+
+    it('stats inicial debe tener todos los valores en 0', () => {
+      const stats = store.stats();
+      expect(stats.total).toBe(0);
+      expect(stats.active).toBe(0);
+      expect(stats.inactive).toBe(0);
+    });
+  });
+
+  describe('loadEmployees()', () => {
+    it('debe cargar empleados y actualizar el estado', async () => {
+      employeesServiceSpy.getAllEmployees.and.returnValue(of(mockEmployees));
+
+      await firstValueFrom(store.loadEmployees());
+
+      expect(store.employees()).toEqual(mockEmployees);
+      expect(store.isLoading()).toBeFalse();
+      expect(store.error()).toBeNull();
+    });
+
+    it('debe manejar error del servicio y actualizar store.error()', async () => {
+      employeesServiceSpy.getAllEmployees.and.returnValue(throwError(() => new Error('Network error')));
+
+      await firstValueFrom(store.loadEmployees());
+
+      expect(store.error()).toBe('Error al cargar empleados');
+      expect(store.isLoading()).toBeFalse();
+      expect(store.employees()).toEqual([]);
+    });
+  });
+
+  describe('stats computed', () => {
+    it('debe calcular estadísticas correctamente', async () => {
+      employeesServiceSpy.getAllEmployees.and.returnValue(of(mockEmployees));
+      await firstValueFrom(store.loadEmployees());
+
+      const stats = store.stats();
+      expect(stats.total).toBe(3);
+      expect(stats.active).toBe(2);
+      expect(stats.inactive).toBe(1);
+    });
+  });
+
+  describe('upsertEmployee()', () => {
+    beforeEach(async () => {
+      employeesServiceSpy.getAllEmployees.and.returnValue(of(mockEmployees));
+      await firstValueFrom(store.loadEmployees());
+    });
+
+    it('debe actualizar un empleado existente por ID', () => {
+      const updated: Employee = { ...mockEmployees[0], fullName: 'Ana García Modificada' };
+      store.upsertEmployee(updated);
+
+      const found = store.employees().find((e) => e.id === 'e1');
+      expect(found?.fullName).toBe('Ana García Modificada');
+      expect(store.employees().length).toBe(3);
+    });
+
+    it('debe agregar un empleado nuevo si el ID no existe', () => {
+      const newEmployee: Employee = { id: 'e4', fullName: 'Carlos Díaz', email: 'carlos@mail.com', documentType: 'CC', documentNumber: '444', status: EmployeeStatus.ACTIVE };
+      store.upsertEmployee(newEmployee);
+
+      expect(store.employees().length).toBe(4);
+      expect(store.employees().find((e) => e.id === 'e4')).toBeTruthy();
+    });
+  });
+
+  describe('removeEmployee()', () => {
+    beforeEach(async () => {
+      employeesServiceSpy.getAllEmployees.and.returnValue(of(mockEmployees));
+      await firstValueFrom(store.loadEmployees());
+    });
+
+    it('debe eliminar el empleado con el ID indicado', () => {
+      store.removeEmployee('e1');
+
+      expect(store.employees().length).toBe(2);
+      expect(store.employees().find((e) => e.id === 'e1')).toBeUndefined();
+    });
+
+    it('no debe modificar la lista si el ID no existe', () => {
+      store.removeEmployee('inexistente');
+      expect(store.employees().length).toBe(3);
+    });
+  });
+
+  describe('clearError()', () => {
+    it('debe limpiar el error del estado', async () => {
+      employeesServiceSpy.getAllEmployees.and.returnValue(throwError(() => new Error('fail')));
+      await firstValueFrom(store.loadEmployees());
+      expect(store.error()).not.toBeNull();
+
+      store.clearError();
+      expect(store.error()).toBeNull();
+    });
+  });
+});

--- a/src/app/modules/private/employees/store/employees.store.ts
+++ b/src/app/modules/private/employees/store/employees.store.ts
@@ -1,0 +1,76 @@
+import { computed, inject } from '@angular/core';
+import {
+  patchState,
+  signalStore,
+  withComputed,
+  withMethods,
+  withState,
+} from '@ngrx/signals';
+import { Observable, catchError, of, tap } from 'rxjs';
+import { Employee, EmployeeStatus } from '../models/employe.model';
+import { EmployeesService } from '../services/employees.service';
+
+interface EmployeesState {
+  employees: Employee[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+/**
+ * Store centralizado para gestionar el estado de los empleados.
+ * @since 2026-05-13
+ * @author BunnyString
+ */
+export const EmployeesStore = signalStore(
+  { providedIn: 'root' },
+  withState<EmployeesState>({
+    employees: [],
+    isLoading: false,
+    error: null,
+  }),
+  withComputed(({ employees }) => ({
+    stats: computed(() => {
+      const list = employees();
+      return {
+        total: list.length,
+        active: list.filter((e) => e.status === EmployeeStatus.ACTIVE).length,
+        inactive: list.filter((e) => e.status === EmployeeStatus.INACTIVE).length,
+      };
+    }),
+  })),
+  withMethods((store) => {
+    const employeesService = inject(EmployeesService);
+
+    return {
+      loadEmployees(): Observable<Employee[]> {
+        patchState(store, { isLoading: true, error: null });
+        return employeesService.getAllEmployees().pipe(
+          tap((employees) => patchState(store, { employees, isLoading: false })),
+          catchError((err) => {
+            console.error('Error al cargar empleados:', err);
+            patchState(store, { error: 'Error al cargar empleados', isLoading: false });
+            return of([]);
+          }),
+        );
+      },
+
+      upsertEmployee(employee: Employee): void {
+        patchState(store, (state) => ({
+          employees: state.employees.some((e) => e.id === employee.id)
+            ? state.employees.map((e) => (e.id === employee.id ? employee : e))
+            : [...state.employees, employee],
+        }));
+      },
+
+      removeEmployee(id: string): void {
+        patchState(store, (state) => ({
+          employees: state.employees.filter((e) => e.id !== id),
+        }));
+      },
+
+      clearError(): void {
+        patchState(store, { error: null });
+      },
+    };
+  }),
+);

--- a/src/app/modules/private/groups/groups.routes.ts
+++ b/src/app/modules/private/groups/groups.routes.ts
@@ -1,4 +1,5 @@
-import { Routes } from "@angular/router";
+import { Routes } from '@angular/router';
+import { groupsResolver } from './resolvers/groups-resolver';
 
 /**
  * Rutas del módulo de grupos con lazy loading
@@ -11,6 +12,7 @@ export const GROUPS_ROUTES: Routes = [
   {
     path: '',
     loadComponent: () => import('./pages/groups/groups.component').then(m => m.GroupsComponent),
+    resolve: { groups: groupsResolver },
     data: {
       breadcrumb: 'Grupos',
       title: 'Gestión de Grupos',
@@ -28,5 +30,5 @@ export const GROUPS_ROUTES: Routes = [
     path: '**',
     redirectTo: '',
     pathMatch: 'full',
-  }
+  },
 ];

--- a/src/app/modules/private/groups/pages/groups/groups.component.html
+++ b/src/app/modules/private/groups/pages/groups/groups.component.html
@@ -9,13 +9,13 @@
 
 <div class="container mx-auto px-4 py-6">
 
-  @if (groupsResource.isLoading()) {
+  @if (store.isLoading()) {
     <div class="flex justify-center py-16">
       <span class="loading loading-spinner loading-lg text-blue-400"></span>
     </div>
   }
 
-  @if (groupsResource.error()) {
+  @if (store.error()) {
     <!-- ERROR DE CONEXIÓN -->
     <div class="flex flex-col items-center justify-center py-16 px-4 text-center">
       <svg xmlns="http://www.w3.org/2000/svg" class="h-32 w-32 text-error opacity-20 mb-6" fill="none"
@@ -27,8 +27,8 @@
       <p class="text-base-content/60 mb-6 max-w-md">
         Hubo un problema al conectar con el servidor. Por favor verifica tu conexión e intenta nuevamente.
       </p>
-      <button class="btn btn-primary gap-2" (click)="groupsResource.reload()" [disabled]="groupsResource.isLoading()">
-        @if (groupsResource.isLoading()) {
+      <button class="btn btn-primary gap-2" (click)="loadGroups()" [disabled]="store.isLoading()">
+        @if (store.isLoading()) {
           <span class="loading loading-spinner loading-sm"></span>
         } @else {
           <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -123,7 +123,7 @@
         </svg>
         Limpiar
       </button>
-      <button class="btn btn-ghost gap-2 ml-auto" (click)="groupsResource.reload()" [disabled]="loading()">
+      <button class="btn btn-ghost gap-2 ml-auto" (click)="loadGroups()" [disabled]="loading()">
         @if (loading()) {
           <span class="loading loading-spinner loading-xs"></span>
         } @else {
@@ -340,7 +340,7 @@
     }
 
     <!-- SIN DATOS -->
-    @if (stats.total === 0 && !groupsResource.isLoading()) {
+    @if (stats.total === 0 && !store.isLoading()) {
       <div class="py-16 text-center opacity-80">
         <svg class="mx-auto h-24 w-24 text-blue-200" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round"

--- a/src/app/modules/private/groups/pages/groups/groups.component.spec.ts
+++ b/src/app/modules/private/groups/pages/groups/groups.component.spec.ts
@@ -1,15 +1,197 @@
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { of } from 'rxjs';
 import { GroupsComponent } from './groups.component';
+import { GroupsStore } from '../../store/groups.store';
+import { GroupsService } from '../../services/groups.service';
+import { Group } from '../../models/groups.model';
+import { EmployeeStatus } from '../../../employees/models/employe.model';
+
+const mockEmployee = { id: 'e1', fullName: 'Ana', email: 'ana@mail.com', documentType: 'CC', documentNumber: '111', status: EmployeeStatus.ACTIVE };
+
+const mockGroups: Group[] = [
+  { id: 'g1', name: 'Grupo Alpha', address: 'Av. Siempre Viva', createdAt: '2026-01-01', updatedAt: null, employees: [mockEmployee] },
+  { id: 'g2', name: 'Grupo Beta', address: 'Calle Falsa', createdAt: '2026-01-02', updatedAt: null, employees: [] },
+  { id: 'g3', name: 'Grupo Gamma', address: 'Boulevard Norte', createdAt: '2026-01-03', updatedAt: null, employees: [] },
+];
 
 describe('GroupsComponent', () => {
+  let component: GroupsComponent;
+  let fixture: ComponentFixture<GroupsComponent>;
+  let groupsServiceSpy: jasmine.SpyObj<GroupsService>;
+
   beforeEach(async () => {
+    groupsServiceSpy = jasmine.createSpyObj('GroupsService', ['getAllGroups']);
+    groupsServiceSpy.getAllGroups.and.returnValue(of(mockGroups));
+
     await TestBed.configureTestingModule({
       imports: [GroupsComponent],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        GroupsStore,
+        { provide: GroupsService, useValue: groupsServiceSpy },
+      ],
     }).compileComponents();
+
+    // Pre-carga el store como lo haría el resolver
+    const store = TestBed.inject(GroupsStore);
+    await store.loadGroups().toPromise();
+
+    fixture = TestBed.createComponent(GroupsComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
   });
 
-  it('should create', () => {
-    const fixture = TestBed.createComponent(GroupsComponent);
-    expect(fixture.componentInstance).toBeTruthy();
+  it('debe crear el componente', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('filteredGroups()', () => {
+    it('debe devolver todos los grupos cuando no hay búsqueda', () => {
+      expect(component.filteredGroups().length).toBe(3);
+    });
+
+    it('debe filtrar por nombre', () => {
+      component.search.set('alpha');
+      expect(component.filteredGroups().length).toBe(1);
+      expect(component.filteredGroups()[0].name).toBe('Grupo Alpha');
+    });
+
+    it('debe filtrar por dirección', () => {
+      component.search.set('boulevard');
+      expect(component.filteredGroups().length).toBe(1);
+      expect(component.filteredGroups()[0].name).toBe('Grupo Gamma');
+    });
+
+    it('debe ser insensible a mayúsculas', () => {
+      component.search.set('BETA');
+      expect(component.filteredGroups().length).toBe(1);
+    });
+
+    it('debe devolver lista vacía si no hay coincidencias', () => {
+      component.search.set('xyz999');
+      expect(component.filteredGroups().length).toBe(0);
+    });
+  });
+
+  describe('filteredStats()', () => {
+    it('debe calcular estadísticas de los grupos filtrados', () => {
+      const stats = component.filteredStats();
+      expect(stats.total).toBe(3);
+      expect(stats.withEmployees).toBe(1);
+      expect(stats.empty).toBe(2);
+    });
+
+    it('debe recalcular stats al cambiar el filtro', () => {
+      component.search.set('alpha');
+      const stats = component.filteredStats();
+      expect(stats.total).toBe(1);
+      expect(stats.withEmployees).toBe(1);
+      expect(stats.empty).toBe(0);
+    });
+  });
+
+  describe('paginación', () => {
+    it('totalItems debe reflejar los grupos filtrados', () => {
+      expect(component.totalItems()).toBe(3);
+    });
+
+    it('pagedGroups debe respetar el tamaño de página', () => {
+      component.pageSize.set(2);
+      expect(component.pagedGroups().length).toBe(2);
+    });
+
+    it('goToPage debe actualizar la página actual', () => {
+      component.pageSize.set(2);
+      component.goToPage(2);
+      expect(component.page()).toBe(2);
+    });
+
+    it('nextPage no debe superar el total de páginas', () => {
+      component.pageSize.set(2);
+      component.goToPage(2); // última página con 2 items por página
+      component.nextPage();
+      expect(component.page()).toBe(2);
+    });
+
+    it('previousPage no debe bajar de la página 1', () => {
+      component.previousPage();
+      expect(component.page()).toBe(1);
+    });
+  });
+
+  describe('onSearchChange()', () => {
+    it('debe actualizar la búsqueda y resetear la página', () => {
+      component.goToPage(2);
+      component.onSearchChange('alpha');
+      expect(component.search()).toBe('alpha');
+      expect(component.page()).toBe(1);
+    });
+  });
+
+  describe('resetFilters()', () => {
+    it('debe limpiar búsqueda y volver a página 1', () => {
+      component.search.set('test');
+      component.page.set(3);
+      component.resetFilters();
+      expect(component.search()).toBe('');
+      expect(component.page()).toBe(1);
+    });
+  });
+
+  describe('gestión de modales', () => {
+    it('openCreateModal debe activar showCreateModal', () => {
+      component.openCreateModal();
+      expect(component.showCreateModal()).toBeTrue();
+      expect(component.showEditModal()).toBeFalse();
+      expect(component.groupToEdit()).toBeNull();
+    });
+
+    it('openEditModal debe activar showEditModal con el grupo', () => {
+      component.openEditModal(mockGroups[0]);
+      expect(component.showEditModal()).toBeTrue();
+      expect(component.showCreateModal()).toBeFalse();
+      expect(component.groupToEdit()).toEqual(mockGroups[0]);
+    });
+
+    it('openDeleteModal debe activar showDeleteModal con el grupo', () => {
+      component.openDeleteModal(mockGroups[1]);
+      expect(component.showDeleteModal()).toBeTrue();
+      expect(component.groupToDelete()).toEqual(mockGroups[1]);
+    });
+
+    it('closeModals debe cerrar todos los modales', () => {
+      component.openCreateModal();
+      component.closeModals();
+      expect(component.showCreateModal()).toBeFalse();
+      expect(component.showEditModal()).toBeFalse();
+      expect(component.showDeleteModal()).toBeFalse();
+      expect(component.groupToEdit()).toBeNull();
+      expect(component.groupToDelete()).toBeNull();
+    });
+
+    it('cancelDelete debe cerrar modal de eliminación', () => {
+      component.openDeleteModal(mockGroups[0]);
+      component.cancelDelete();
+      expect(component.showDeleteModal()).toBeFalse();
+      expect(component.groupToDelete()).toBeNull();
+    });
+  });
+
+  describe('getShortText()', () => {
+    it('debe truncar texto largo', () => {
+      const result = component.getShortText('Este es un texto muy largo que debe ser truncado');
+      expect(result.length).toBeLessThanOrEqual(31); // 30 chars + '…'
+      expect(result.endsWith('…')).toBeTrue();
+    });
+
+    it('debe devolver texto corto sin truncar', () => {
+      const result = component.getShortText('Texto corto');
+      expect(result).toBe('Texto corto');
+    });
   });
 });

--- a/src/app/modules/private/groups/pages/groups/groups.component.ts
+++ b/src/app/modules/private/groups/pages/groups/groups.component.ts
@@ -1,27 +1,27 @@
 import {
-  Component,
   ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  OnInit,
   computed,
-  effect,
   inject,
-  resource,
   signal,
 } from '@angular/core';
 import { DatePipe } from '@angular/common';
 import { toSignal } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
-import { firstValueFrom } from 'rxjs';
 import { Group, GroupFormResult } from '../../models/groups.model';
 import { toast } from 'ngx-sonner';
 import { GroupCreateEditModalComponent } from '../../modals/group-create-edit-modal/group-create-edit-modal.component';
 import { GroupDeleteModalComponent } from '../../modals/group-delete-modal/group-delete-modal.component';
 import { LoadingService } from '../../../../../core/services/loading.service';
-import { GroupsService } from '../../services/groups.service';
+import { GroupsStore } from '../../store/groups.store';
 
 /**
  * Componente principal del módulo de grupos
  *
- * @since 2026-05-11
+ * @since 2026-05-13
  * @author Bunnystring
  */
 @Component({
@@ -32,16 +32,12 @@ import { GroupsService } from '../../services/groups.service';
   templateUrl: './groups.component.html',
   styleUrl: './groups.component.css',
 })
-export class GroupsComponent {
-  private readonly groupsService = inject(GroupsService);
-  private readonly loadingService = inject(LoadingService);
+export class GroupsComponent implements OnInit {
+  protected readonly store = inject(GroupsStore);
   private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
 
-  readonly loading = toSignal(this.loadingService.loading$, { initialValue: false });
-
-  readonly groupsResource = resource({
-    loader: () => firstValueFrom(this.groupsService.getAllGroups()),
-  });
+  readonly loading = toSignal(inject(LoadingService).loading$, { initialValue: false });
 
   readonly search = signal('');
   readonly page = signal(1);
@@ -54,13 +50,13 @@ export class GroupsComponent {
   readonly groupToDelete = signal<Group | null>(null);
 
   readonly filteredGroups = computed(() => {
-    const groups = this.groupsResource.value() ?? [];
-    const search = this.search().toLowerCase();
-    if (!search) return groups;
+    const s = this.search().toLowerCase();
+    const groups = this.store.groups();
+    if (!s) return groups;
     return groups.filter(
       (g) =>
-        g.name.toLowerCase().includes(search) ||
-        g.address.toLowerCase().includes(search),
+        g.name.toLowerCase().includes(s) ||
+        g.address.toLowerCase().includes(s),
     );
   });
 
@@ -84,18 +80,18 @@ export class GroupsComponent {
     return this.filteredGroups().slice(start, start + this.pageSize());
   });
 
-  constructor() {
-    effect(() => {
-      if (this.groupsResource.error()) {
-        toast.error('Error al obtener grupos');
-      }
-    });
-    effect(() => {
-      const groups = this.groupsResource.value();
-      if (groups !== undefined && groups.length === 0) {
-        toast.info('No hay grupos para mostrar actualmente.');
-      }
-    });
+  get groupError() { return !!this.store.error(); }
+
+  ngOnInit(): void {
+    if (this.store.error()) {
+      toast.error('No se pudo conectar al microservicio de grupos.');
+    } else if (this.store.groups().length === 0) {
+      toast.info('No hay grupos para mostrar actualmente.');
+    }
+  }
+
+  loadGroups(): void {
+    this.store.loadGroups().pipe(takeUntilDestroyed(this.destroyRef)).subscribe();
   }
 
   onSearchChange(value: string): void {
@@ -133,7 +129,7 @@ export class GroupsComponent {
   onGroupDeleted(): void {
     this.showDeleteModal.set(false);
     this.groupToDelete.set(null);
-    this.groupsResource.reload();
+    this.loadGroups();
   }
 
   cancelDelete(): void {
@@ -151,8 +147,12 @@ export class GroupsComponent {
 
   handleModalSave({ mode }: GroupFormResult): void {
     toast.success(mode === 'create' ? 'Grupo creado' : 'Grupo actualizado');
-    this.groupsResource.reload();
+    this.loadGroups();
     this.closeModals();
+  }
+
+  clearError(): void {
+    this.store.clearError();
   }
 
   goToDetail(group: Group): void {

--- a/src/app/modules/private/groups/resolvers/groups-resolver.ts
+++ b/src/app/modules/private/groups/resolvers/groups-resolver.ts
@@ -1,0 +1,7 @@
+import { inject } from '@angular/core';
+import { ResolveFn } from '@angular/router';
+import { map } from 'rxjs';
+import { GroupsStore } from '../store/groups.store';
+
+export const groupsResolver: ResolveFn<boolean> = () =>
+  inject(GroupsStore).loadGroups().pipe(map(() => true));

--- a/src/app/modules/private/groups/services/groups.service.spec.ts
+++ b/src/app/modules/private/groups/services/groups.service.spec.ts
@@ -1,15 +1,140 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 import { GroupsService } from './groups.service';
+import { Group, CreateGroupRq } from '../models/groups.model';
+import { EmployeeStatus } from '../../employees/models/employe.model';
+import { environment } from '../../../../../environments/environment';
+
+const BASE = environment.apiUrl;
+
+const mockEmployee = { id: 'e1', fullName: 'Ana', email: 'ana@mail.com', documentType: 'CC', documentNumber: '111', status: EmployeeStatus.ACTIVE };
+
+const mockGroup: Group = {
+  id: 'g1',
+  name: 'Grupo Test',
+  address: 'Calle 123',
+  createdAt: '2026-01-01',
+  updatedAt: null,
+  employees: [mockEmployee],
+};
 
 describe('GroupsService', () => {
+  let service: GroupsService;
+  let httpMock: HttpTestingController;
+
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [GroupsService],
+      providers: [
+        GroupsService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
     });
+
+    service = TestBed.inject(GroupsService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('debe ser creado', () => {
-    const service = TestBed.inject(GroupsService);
     expect(service).toBeTruthy();
+  });
+
+  describe('getAllGroups()', () => {
+    it('debe hacer GET /groups y devolver lista', () => {
+      service.getAllGroups().subscribe((groups) => {
+        expect(groups.length).toBe(1);
+        expect(groups[0].id).toBe('g1');
+      });
+
+      const req = httpMock.expectOne(`${BASE}/groups`);
+      expect(req.request.method).toBe('GET');
+      req.flush([mockGroup]);
+    });
+  });
+
+  describe('getGroupById()', () => {
+    it('debe hacer GET /groups/:id y devolver el grupo', () => {
+      service.getGroupById('g1').subscribe((group) => {
+        expect(group.id).toBe('g1');
+        expect(group.name).toBe('Grupo Test');
+      });
+
+      const req = httpMock.expectOne(`${BASE}/groups/g1`);
+      expect(req.request.method).toBe('GET');
+      req.flush(mockGroup);
+    });
+  });
+
+  describe('createGroup()', () => {
+    it('debe hacer POST /groups con los datos correctos', () => {
+      const payload: Partial<CreateGroupRq> = { name: 'Nuevo Grupo', address: 'Av. Nueva' };
+
+      service.createGroup(payload).subscribe((group) => {
+        expect(group.name).toBe('Nuevo Grupo');
+      });
+
+      const req = httpMock.expectOne(`${BASE}/groups`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual(payload);
+      req.flush({ ...mockGroup, ...payload });
+    });
+  });
+
+  describe('updateGroup()', () => {
+    it('debe hacer PUT /groups/:id con los datos correctos', () => {
+      const payload: Partial<CreateGroupRq> = { name: 'Grupo Actualizado' };
+
+      service.updateGroup('g1', payload).subscribe((group) => {
+        expect(group.name).toBe('Grupo Actualizado');
+      });
+
+      const req = httpMock.expectOne(`${BASE}/groups/g1`);
+      expect(req.request.method).toBe('PUT');
+      expect(req.request.body).toEqual(payload);
+      req.flush({ ...mockGroup, name: 'Grupo Actualizado' });
+    });
+  });
+
+  describe('deleteGroupById()', () => {
+    it('debe hacer DELETE /groups/:id', () => {
+      service.deleteGroupById('g1').subscribe((res) => {
+        expect(res).toBeNull();
+      });
+
+      const req = httpMock.expectOne(`${BASE}/groups/g1`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null);
+    });
+  });
+
+  describe('removeEmployeesFromGroup()', () => {
+    it('debe hacer DELETE /groups/:groupId/employees/:employeeId', () => {
+      service.removeEmployeesFromGroup('g1', 'e1').subscribe((group) => {
+        expect(group).toBeTruthy();
+      });
+
+      const req = httpMock.expectOne(`${BASE}/groups/g1/employees/e1`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush({ ...mockGroup, employees: [] });
+    });
+  });
+
+  describe('getEmailsByGroup()', () => {
+    it('debe hacer GET /groups/:groupId/members/emails', () => {
+      const emails = ['ana@mail.com'];
+
+      service.getEmailsByGroup('g1').subscribe((result) => {
+        expect(result).toEqual(emails);
+      });
+
+      const req = httpMock.expectOne(`${BASE}/groups/g1/members/emails`);
+      expect(req.request.method).toBe('GET');
+      req.flush(emails);
+    });
   });
 });

--- a/src/app/modules/private/groups/store/groups.store.spec.ts
+++ b/src/app/modules/private/groups/store/groups.store.spec.ts
@@ -1,0 +1,152 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { of, throwError } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
+import { GroupsStore } from './groups.store';
+import { GroupsService } from '../services/groups.service';
+import { Group } from '../models/groups.model';
+
+const mockEmployee = { id: 'e1', fullName: 'Ana', email: 'ana@mail.com', documentType: 'CC', documentNumber: '123', status: 'ACTIVE' as any };
+
+const mockGroups: Group[] = [
+  { id: 'g1', name: 'Grupo A', address: 'Calle 1', createdAt: '2026-01-01', updatedAt: null, employees: [mockEmployee] },
+  { id: 'g2', name: 'Grupo B', address: 'Calle 2', createdAt: '2026-01-02', updatedAt: null, employees: [] },
+];
+
+describe('GroupsStore', () => {
+  let store: InstanceType<typeof GroupsStore>;
+  let groupsServiceSpy: jasmine.SpyObj<GroupsService>;
+
+  beforeEach(() => {
+    groupsServiceSpy = jasmine.createSpyObj('GroupsService', ['getAllGroups']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        GroupsStore,
+        { provide: GroupsService, useValue: groupsServiceSpy },
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    store = TestBed.inject(GroupsStore);
+  });
+
+  describe('Estado inicial', () => {
+    it('debe inicializar con lista vacía', () => {
+      expect(store.groups()).toEqual([]);
+    });
+
+    it('debe inicializar sin carga activa', () => {
+      expect(store.isLoading()).toBeFalse();
+    });
+
+    it('debe inicializar sin error', () => {
+      expect(store.error()).toBeNull();
+    });
+
+    it('stats inicial debe tener todos los valores en 0', () => {
+      const stats = store.stats();
+      expect(stats.total).toBe(0);
+      expect(stats.withEmployees).toBe(0);
+      expect(stats.empty).toBe(0);
+    });
+  });
+
+  describe('loadGroups()', () => {
+    it('debe cargar grupos y actualizar el estado', async () => {
+      groupsServiceSpy.getAllGroups.and.returnValue(of(mockGroups));
+
+      await firstValueFrom(store.loadGroups());
+
+      expect(store.groups()).toEqual(mockGroups);
+      expect(store.isLoading()).toBeFalse();
+      expect(store.error()).toBeNull();
+    });
+
+    it('debe activar isLoading al iniciar y desactivarlo al terminar', async () => {
+      groupsServiceSpy.getAllGroups.and.returnValue(of(mockGroups));
+      const loading$ = store.loadGroups();
+      // Al suscribirse isLoading se activa internamente y luego se desactiva
+      await firstValueFrom(loading$);
+      expect(store.isLoading()).toBeFalse();
+    });
+
+    it('debe manejar error del servicio y actualizar store.error()', async () => {
+      groupsServiceSpy.getAllGroups.and.returnValue(throwError(() => new Error('Network error')));
+
+      await firstValueFrom(store.loadGroups());
+
+      expect(store.error()).toBe('Error al cargar grupos');
+      expect(store.isLoading()).toBeFalse();
+      expect(store.groups()).toEqual([]);
+    });
+  });
+
+  describe('stats computed', () => {
+    it('debe calcular estadísticas correctamente', async () => {
+      groupsServiceSpy.getAllGroups.and.returnValue(of(mockGroups));
+      await firstValueFrom(store.loadGroups());
+
+      const stats = store.stats();
+      expect(stats.total).toBe(2);
+      expect(stats.withEmployees).toBe(1);
+      expect(stats.empty).toBe(1);
+    });
+  });
+
+  describe('upsertGroup()', () => {
+    beforeEach(async () => {
+      groupsServiceSpy.getAllGroups.and.returnValue(of(mockGroups));
+      await firstValueFrom(store.loadGroups());
+    });
+
+    it('debe actualizar un grupo existente por ID', () => {
+      const updated: Group = { ...mockGroups[0], name: 'Grupo A Modificado' };
+      store.upsertGroup(updated);
+
+      const found = store.groups().find((g) => g.id === 'g1');
+      expect(found?.name).toBe('Grupo A Modificado');
+      expect(store.groups().length).toBe(2);
+    });
+
+    it('debe agregar un grupo nuevo si el ID no existe', () => {
+      const newGroup: Group = { id: 'g3', name: 'Grupo C', address: 'Calle 3', createdAt: '2026-01-03', updatedAt: null, employees: [] };
+      store.upsertGroup(newGroup);
+
+      expect(store.groups().length).toBe(3);
+      expect(store.groups().find((g) => g.id === 'g3')).toBeTruthy();
+    });
+  });
+
+  describe('removeGroup()', () => {
+    beforeEach(async () => {
+      groupsServiceSpy.getAllGroups.and.returnValue(of(mockGroups));
+      await firstValueFrom(store.loadGroups());
+    });
+
+    it('debe eliminar el grupo con el ID indicado', () => {
+      store.removeGroup('g1');
+
+      expect(store.groups().length).toBe(1);
+      expect(store.groups().find((g) => g.id === 'g1')).toBeUndefined();
+    });
+
+    it('no debe modificar la lista si el ID no existe', () => {
+      store.removeGroup('inexistente');
+      expect(store.groups().length).toBe(2);
+    });
+  });
+
+  describe('clearError()', () => {
+    it('debe limpiar el error del estado', async () => {
+      groupsServiceSpy.getAllGroups.and.returnValue(throwError(() => new Error('fail')));
+      await firstValueFrom(store.loadGroups());
+      expect(store.error()).not.toBeNull();
+
+      store.clearError();
+      expect(store.error()).toBeNull();
+    });
+  });
+});

--- a/src/app/modules/private/groups/store/groups.store.ts
+++ b/src/app/modules/private/groups/store/groups.store.ts
@@ -1,0 +1,76 @@
+import { computed, inject } from '@angular/core';
+import {
+  patchState,
+  signalStore,
+  withComputed,
+  withMethods,
+  withState,
+} from '@ngrx/signals';
+import { Observable, catchError, of, tap } from 'rxjs';
+import { Group } from '../models/groups.model';
+import { GroupsService } from '../services/groups.service';
+
+interface GroupsState {
+  groups: Group[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+/**
+ * Store centralizado para gestionar el estado de los grupos.
+ * @since 2026-05-13
+ * @author BunnyString
+ */
+export const GroupsStore = signalStore(
+  { providedIn: 'root' },
+  withState<GroupsState>({
+    groups: [],
+    isLoading: false,
+    error: null,
+  }),
+  withComputed(({ groups }) => ({
+    stats: computed(() => {
+      const list = groups();
+      return {
+        total: list.length,
+        withEmployees: list.filter((g) => g.employees?.length > 0).length,
+        empty: list.filter((g) => !g.employees?.length).length,
+      };
+    }),
+  })),
+  withMethods((store) => {
+    const groupsService = inject(GroupsService);
+
+    return {
+      loadGroups(): Observable<Group[]> {
+        patchState(store, { isLoading: true, error: null });
+        return groupsService.getAllGroups().pipe(
+          tap((groups) => patchState(store, { groups, isLoading: false })),
+          catchError((err) => {
+            console.error('Error al cargar grupos:', err);
+            patchState(store, { error: 'Error al cargar grupos', isLoading: false });
+            return of([]);
+          }),
+        );
+      },
+
+      upsertGroup(group: Group): void {
+        patchState(store, (state) => ({
+          groups: state.groups.some((g) => g.id === group.id)
+            ? state.groups.map((g) => (g.id === group.id ? group : g))
+            : [...state.groups, group],
+        }));
+      },
+
+      removeGroup(id: string): void {
+        patchState(store, (state) => ({
+          groups: state.groups.filter((g) => g.id !== id),
+        }));
+      },
+
+      clearError(): void {
+        patchState(store, { error: null });
+      },
+    };
+  }),
+);


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción
Este PR introduce una refactorización en los módulos de **Empleados** y **Grupos** para mover la carga y gestión del estado hacia stores basados en señales, apoyados por resolvers que precargan la información antes de renderizar las páginas principales.

En **Empleados**, el componente deja de depender de un `resource()` local para consumir el estado desde `EmployeesStore`, incorporando un método explícito de recarga (`loadEmployees()`), manejo de errores centralizado y limpieza manual del error. También se agrega `employeesResolver` para cargar la información al entrar a la ruta.

En **Grupos**, se aplica el mismo patrón: la ruta ahora usa `groupsResolver`, la vista consume `store.isLoading()` y `store.error()` en lugar del recurso anterior, y la acción de recarga manual se conecta al store.

Adicionalmente, este PR fortalece la base de pruebas unitarias:
- Se amplían los tests de `EmployeesComponent` para cubrir filtros, estadísticas, paginación, búsqueda, modales, truncado de texto y comportamiento general del componente.
- Se agregan pruebas para `EmployeesService`, validando llamadas HTTP `GET`, `POST`, `PUT` y `DELETE`.
- Se agregan pruebas para `EmployeesStore`, validando estado inicial, carga exitosa, manejo de errores, estadísticas derivadas, actualización/inserción de empleados y eliminación.
- Se amplían también los tests de `GroupsComponent` para cubrir filtros, estadísticas, paginación, búsqueda, modales y truncado de texto.

En resumen, el PR busca:
- centralizar el estado de empleados y grupos,
- precargar datos desde routing,
- simplificar el consumo de datos en componentes,
- mejorar el manejo de errores y recarga,
- y aumentar la cobertura de pruebas del módulo.

## ¿Qué tipo de cambio es?
- [ ] Bugfix 🐞
- [x] Feature ✨
- [x] Refactor 🔧
- [ ] Documentación 📚
- [ ] Otro

## Archivos modificados

### `src/app/modules/private/employees/employees.routes.ts`
- Se agrega el import de `employeesResolver`.
- Se incorpora `resolve: { employees: employeesResolver }` en la ruta principal del módulo.
- Esto permite precargar la lista de empleados antes de cargar la página.

### `src/app/modules/private/employees/pages/employees/employees.component.html`
- Se reemplazan referencias a `employeesResource.error()` por `store.error()`.
- Se reemplazan acciones de recarga `employeesResource.reload()` por `loadEmployees()`.
- Se reemplaza `employeesResource.isLoading()` por `store.isLoading()` en estados vacíos.
- La plantilla ahora depende del store como fuente principal de estado.

### `src/app/modules/private/employees/pages/employees/employees.component.ts`
- Se elimina la dependencia principal de `resource()` y `EmployeesService` como fuente de datos del componente.
- Se adopta `EmployeesStore` como origen del estado.
- Se implementa `OnInit`.
- Se agrega `DestroyRef` y `takeUntilDestroyed` para manejar la suscripción de recarga.
- `filteredEmployees` ahora filtra sobre `this.store.employees()`.
- Se agrega `loadEmployees()` para disparar la carga desde el store.
- Se actualizan `onEmployeeDeleted()` y `handleModalSave()` para refrescar datos usando el store.
- Se agrega `clearError()` para limpiar el error en el estado global.
- Se ajustan notificaciones tipo toast para responder al estado del store.

### `src/app/modules/private/employees/resolvers/employees-resolver.ts`
- Nuevo archivo.
- Se crea `employeesResolver` como `ResolveFn<boolean>`.
- Ejecuta `EmployeesStore.loadEmployees()` y retorna `true` cuando finaliza.

### `src/app/modules/private/employees/pages/employees/employees.component.spec.ts`
- Se amplía de forma considerable la cobertura de pruebas.
- Se agregan escenarios para:
  - creación del componente,
  - filtrado por nombre y email,
  - búsqueda case-insensitive,
  - estadísticas filtradas,
  - paginación,
  - cambio de tamaño de página,
  - reseteo de filtros,
  - apertura/cierre de modales,
  - cancelación de eliminación,
  - truncado de texto.
- Se usa `EmployeesStore` precargado con datos mock.
- Se mockea `EmployeesService`.

### `src/app/modules/private/employees/services/employees.service.spec.ts`
- Se agregan pruebas HTTP completas para el servicio.
- Se validan endpoints:
  - `GET /employees`
  - `GET /employees/:id`
  - `POST /employees`
  - `PUT /employees/:id`
  - `DELETE /employees/:id`
- Se usa `HttpTestingController` y `provideHttpClientTesting()`.

### `src/app/modules/private/employees/store/employees.store.ts`
- Nuevo archivo.
- Se crea `EmployeesStore` con `@ngrx/signals`.
- Estado incluido:
  - `employees`
  - `isLoading`
  - `error`
- Computed incluido:
  - `stats` con total, activos e inactivos.
- Methods incluidos:
  - `loadEmployees()`
  - `upsertEmployee()`
  - `removeEmployee()`
  - `clearError()`
- Se centraliza el manejo de carga y error del módulo.

### `src/app/modules/private/employees/store/employees.store.spec.ts`
- Nuevo archivo.
- Se agregan pruebas para:
  - estado inicial,
  - carga exitosa,
  - carga con error,
  - estadísticas derivadas,
  - actualización/inserción de empleados,
  - eliminación de empleados,
  - limpieza de errores.

### `src/app/modules/private/groups/groups.routes.ts`
- Se normaliza el import de `Routes` con comillas simples.
- Se agrega el import de `groupsResolver`.
- Se incorpora `resolve: { groups: groupsResolver }` en la ruta principal.
- También se ajusta formato del archivo.

### `src/app/modules/private/groups/pages/groups/groups.component.html`
- Se reemplazan referencias de `groupsResource.isLoading()` por `store.isLoading()`.
- Se reemplazan referencias de `groupsResource.error()` por `store.error()`.
- Se actualizan botones de recarga para usar `loadGroups()`.
- Se ajusta el estado “sin datos” para depender de `store.isLoading()`.

### `src/app/modules/private/groups/pages/groups/groups.component.spec.ts`
- Se amplían las pruebas del componente de grupos.
- Se cubren escenarios de:
  - render y creación,
  - filtros por nombre y dirección,
  - búsqueda case-insensitive,
  - estadísticas filtradas,
  - paginación,
  - reseteo de búsqueda,
  - modales de crear, editar y eliminar,
  - truncado de texto.
- Se mockea `GroupsService` y se precarga `GroupsStore`.

## ¿Qué tipo de cambio funcional introduce?
Este PR cambia la manera en que los módulos obtienen y administran sus datos:
- Antes: cada componente dependía más directamente de recursos locales para carga y refresco.
- Ahora: el estado se centraliza en stores reutilizables, y las rutas se encargan de precargar los datos necesarios.

Esto mejora:
- consistencia en la gestión del estado,
- reutilización,
- testabilidad,
- separación de responsabilidades,
- experiencia de navegación al cargar datos antes de mostrar la pantalla.

## ¿Cómo probar estos cambios?

### Prueba manual
1. Levantar la aplicación.
2. Ingresar a la ruta de **Empleados**.
3. Verificar que el listado cargue automáticamente al entrar.
4. Validar que el breadcrumb y título sigan funcionando correctamente.
5. Probar la búsqueda por nombre y correo.
6. Cambiar el tamaño de página y navegar entre páginas.
7. Usar el botón **Limpiar** y confirmar que restablece filtros.
8. Usar el botón de recarga y confirmar que dispara una nueva carga.
9. Crear, editar y eliminar empleados verificando que la lista se actualiza después de cada operación.
10. Simular error de backend o desconexión y verificar que se muestre el estado de error.
11. Ingresar a la ruta de **Grupos**.
12. Confirmar que la lista se precarga correctamente.
13. Validar estados de loading, error, vacío, búsqueda y recarga manual.
14. Probar paginación y modales del módulo de grupos.

### Pruebas automatizadas
Ejecutar:

```bash
npm test
```

o según la configuración del proyecto:

```bash
ng test
```

Si aplica, también ejecutar:

```bash
npm run lint
```

## Checklist
- [x] El código compila y pasa los tests
- [ ] La documentación está actualizada (si aplica)
- [x] No hay warnings nuevos
- [x] Revisé el formato y convenciones de código

## Screenshots (si aplica)
No aplica, ya que los cambios son mayormente estructurales y de lógica de estado, aunque sí impactan el flujo visual de carga/error/empty state.

## Issue relacionada
<!-- Si hay issues asociadas, referencia: closes #123 -->
No aplica / no especificada.

## Notas para el revisor
- El objetivo principal del PR es estandarizar el patrón de carga de datos entre módulos.
- `EmployeesStore` se introduce como nueva pieza central para empleados; grupos parece seguir una estrategia equivalente desde la vista.
- Los resolvers ahora forman parte del flujo de navegación, por lo que conviene revisar que no haya efectos secundarios no deseados en rutas hijas o navegación repetida.
- Hay una expansión importante de tests, por lo que vale la pena revisar:
  - consistencia de mocks,
  - uso de `toPromise()` en specs,
  - cobertura de errores,
  - posibles duplicaciones o pequeños problemas de formato heredados en los archivos de prueba.
- También sería útil revisar si este patrón se replicará luego en otros módulos privados para mantener homogeneidad arquitectónica.

## Resumen corto para el título/descripcion del PR
**Refactor de empleados y grupos con stores + resolvers, y ampliación de cobertura de tests**