### PR TITLE
feat(issue-23): Se actualiza configuración dockerFile para node y angular SSR en docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /app
 ENV NODE_ENV=production
 
 # Define hosts permitidos para SSR
-ENV NG_ALLOWED_HOSTS=localhost:4200,127.0.0.1:4200,localhost:4000,127.0.0.1:4000
+ENV NG_ALLOWED_HOSTS=localhost,127.0.0.1
 
 # Copia archivos de dependencias e instala solo las dependencias necesarias de runtime
 COPY package*.json ./
@@ -37,7 +37,7 @@ EXPOSE 4000
 
 # Healthcheck
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --quiet --header="Host: localhost:4000" --tries=1 --spider http://127.0.0.1:4000/ || exit 1
+    CMD wget --quiet --header="Host: localhost" --tries=1 --spider http://127.0.0.1:4000/ || exit 1
 
 # Comando por defecto para arrancar el servidor SSR
 CMD ["node", "dist/infragest-frontend/server/server.mjs"]


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción
Este PR corrige la configuración del `Dockerfile` del frontend para permitir que la aplicación Angular SSR ejecutada con Node acepte correctamente los hosts esperados dentro del contenedor y pase el `healthcheck` configurado.

Anteriormente, `NG_ALLOWED_HOSTS` estaba definido con valores que incluían puerto (`localhost:4200`, `127.0.0.1:4000`, etc.), lo que provocaba que Angular rechazara requests internas con errores de tipo:

```text
Header "host" with value "localhost:4000" is not allowed.
```

Con este cambio:
- `NG_ALLOWED_HOSTS` se simplifica a `localhost,127.0.0.1`
- el `healthcheck` deja de enviar el header `Host: localhost:4000` y pasa a usar `Host: localhost`

Esto alinea la configuración con la validación de hosts esperada por Angular SSR y evita falsos negativos en el estado del contenedor.

## ¿Qué tipo de cambio es?
- [x] Bugfix 🐞
- [ ] Feature ✨
- [ ] Refactor 🔧
- [ ] Documentación 📚
- [ ] Otro

## ¿Cómo probar estos cambios?

### Reconstruir imagen
```bash
docker compose build --no-cache infra-frontend
```

### Levantar el frontend
```bash
docker compose up -d infra-frontend
```

### Verificar estado del contenedor
```bash
docker compose ps
```

Se espera que `infra-frontend` quede en estado `Up` y deje de marcar errores por `host not allowed`.

### Revisar logs
```bash
docker compose logs -f infra-frontend
```

Confirmar que:
- no aparezca el error:
  ```text
  Header "host" with value "localhost:4000" is not allowed.
  ```
- el servidor SSR arranque correctamente.

### Probar acceso local
Abrir:

```text
http://localhost:4200
```

Validar que la aplicación cargue correctamente.

## Checklist
- [x] El código compila y pasa los tests
- [ ] La documentación está actualizada (si aplica)
- [x] No hay warnings nuevos
- [x] Revisé el formato y convenciones de código

## Screenshots (si aplica)
No aplica.

## Issue relacionada
closes #23

## Notas para el revisor
- El cambio es pequeño pero importante para estabilizar el despliegue SSR en Docker.
- Se corrige tanto la allowlist de hosts como el header usado por el `healthcheck`.
- Este ajuste evita que Angular SSR rechace requests internas válidas del propio contenedor.
- Conviene validar que el frontend quede saludable después del rebuild.

## Resumen corto
Se corrige el `Dockerfile` del frontend SSR para usar `NG_ALLOWED_HOSTS` sin puertos y ajustar el `healthcheck` al host permitido por Angular.