### PR TITLE
feat(issue-24): Se agregan logs para validar fetch desde el servidor …

### DIFF
--- a/src/app/core/interceptors/auth.interceptor.ts
+++ b/src/app/core/interceptors/auth.interceptor.ts
@@ -1,5 +1,6 @@
 import { HttpInterceptorFn } from '@angular/common/http';
-import { inject } from '@angular/core';
+import { inject, PLATFORM_ID } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
 import { AuthService } from '../services/auth.service';
 import { Router } from '@angular/router';
 import { catchError, switchMap, throwError } from 'rxjs';
@@ -14,6 +15,10 @@ import { HttpErrorResponse } from '@angular/common/http';
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
   const authService = inject(AuthService);
   const router = inject(Router);
+  const platformId = inject(PLATFORM_ID);
+  const context = isPlatformServer(platformId) ? '[SSR]' : '[BROWSER]';
+
+  console.log(`${context} HTTP ${req.method} → ${req.url}`);
 
   // Lista de endpoints que no requieren token
   const publicEndpoints = ['/auth/login', '/auth/register', '/auth/refresh'];

--- a/src/server.ts
+++ b/src/server.ts
@@ -39,11 +39,18 @@ app.use(
  * Handle all other requests by rendering the Angular application.
  */
 app.use((req, res, next) => {
+  console.log(`\n[SSR SERVER] ➜ ${req.method} ${req.url}`);
   angularApp
     .handle(req)
-    .then((response) =>
-      response ? writeResponseToNodeResponse(response, res) : next(),
-    )
+    .then((response) => {
+      if (response) {
+        console.log(`[SSR SERVER] ✅ Angular renderizó SSR para: ${req.url}`);
+        writeResponseToNodeResponse(response, res);
+      } else {
+        console.log(`[SSR SERVER] ⏭  Sin render SSR (estático o CSR): ${req.url}`);
+        next();
+      }
+    })
     .catch(next);
 });
 


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción
Este PR agrega logging orientado a diagnóstico para verificar cuándo las peticiones HTTP se ejecutan desde SSR y cuándo se ejecutan desde el navegador.

Se instrumentan dos puntos clave:

1. **`src/app/core/interceptors/auth.interceptor.ts`**
   - Se detecta la plataforma actual usando `PLATFORM_ID`
   - Se etiqueta cada request saliente como:
     - `[SSR]` cuando corre en servidor
     - `[BROWSER]` cuando corre en cliente
   - Se imprime un log por cada request HTTP interceptada

2. **`src/server.ts`**
   - Se agregan logs al flujo de render SSR
   - Se registra cuándo entra una request al servidor SSR
   - Se informa si Angular realmente renderizó la ruta en servidor o si la request siguió un flujo estático/CSR

Con esto se facilita validar si los `fetch`/requests ocurren antes de entregar el HTML renderizado o si están siendo ejecutados únicamente en el navegador.

## ¿Qué tipo de cambio es?
- [x] Bugfix 🐞
- [ ] Feature ✨
- [x] Refactor 🔧
- [ ] Documentación 📚
- [ ] Otro

## ¿Cómo probar estos cambios?

### 1. Reconstruir y levantar el frontend
```bash
docker compose build --no-cache infra-frontend
docker compose up -d infra-frontend
```

### 2. Ver logs del frontend
```bash
docker compose logs -f infra-frontend
```

### 3. Abrir la aplicación en el navegador
```text
http://localhost:4200
```

### 4. Validar logs de SSR en consola Docker
Se espera ver mensajes como:

```text
[SSR SERVER] ➜ GET /ruta
[SSR] HTTP GET → http://...
[SSR SERVER] ✅ Angular renderizó SSR para: /ruta
```

Esto indica que:
- la request entró al servidor SSR
- Angular ejecutó llamadas HTTP durante render server-side
- la vista fue renderizada antes de responder

### 5. Validar logs del navegador
Abrir DevTools del navegador y revisar la consola.

Se espera ver mensajes como:

```text
[BROWSER] HTTP GET → http://...
```

Esto permite distinguir claramente qué requests se disparan desde cliente después de hidratar la app.

### 6. Comparar comportamiento SSR vs navegador
- Si aparece `[SSR]`, la llamada ocurrió en servidor
- Si aparece `[BROWSER]`, la llamada ocurrió en cliente
- Si aparecen ambos, probablemente hay una llamada en SSR y otra tras hidratación/re-ejecución en browser

## Checklist
- [x] El código compila y pasa los tests
- [ ] La documentación está actualizada (si aplica)
- [x] No hay warnings nuevos
- [x] Revisé el formato y convenciones de código

## Screenshots (si aplica)
No aplica.

## Issue relacionada
closes #24

## Notas para el revisor
- El objetivo del cambio es diagnóstico y observabilidad durante SSR.
- Los logs permiten confirmar si las peticiones HTTP ocurren antes de enviar el HTML al cliente.
- También facilitan detectar duplicidad de requests entre SSR e hidratación en navegador.
- El cambio no altera la lógica funcional del negocio; solo agrega trazabilidad en puntos clave del flujo HTTP/render.

## Resumen corto
Se agregan logs en el interceptor HTTP y en el servidor SSR para diferenciar llamadas ejecutadas en servidor vs navegador y validar el flujo de renderizado previo al envío del HTML.