### PR TITLE
Merge Main to Dev

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -43,6 +43,12 @@
           },
           "configurations": {
             "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
               "budgets": [
                 {
                   "type": "initial",

--- a/src/app/core/interceptors/auth.interceptor.ts
+++ b/src/app/core/interceptors/auth.interceptor.ts
@@ -3,7 +3,7 @@ import { inject, PLATFORM_ID } from '@angular/core';
 import { isPlatformServer } from '@angular/common';
 import { AuthService } from '../services/auth.service';
 import { Router } from '@angular/router';
-import { catchError, switchMap, throwError } from 'rxjs';
+import { EMPTY, catchError, switchMap, throwError } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
 
 /**
@@ -68,12 +68,10 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
           }),
           catchError((refreshError) => {
             console.error('❌ Fallo al refrescar token:', refreshError);
-
-            // Si el refresh falla, hacer logout y redirigir
-            // console.log('🚪 Cerrando sesión y redirigiendo al login...');
             authService.logout();
-
-            return throwError(() => refreshError);
+            // EMPTY evita que el error llegue a errorInterceptor, que también
+            // navega a /auth/login en 401 — previniendo doble navegación.
+            return EMPTY;
           }),
         );
       }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  apiUrl: 'http://localhost:8080/api'
+  apiUrl: 'https://REPLACE_WITH_PRODUCTION_API_URL/api'
 };


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción
Se ajusta el manejo de autenticación en el interceptor para evitar una doble navegación al login cuando falla el refresh token, y además se actualiza la configuración de entorno de producción para usar una URL de API preparada para despliegue.

También se agregan ajustes en la configuración de `angular.json` relacionados con el entorno de producción.

## ¿Qué tipo de cambio es?
- [x] Bugfix 🐞
- [ ] Feature ✨
- [ ] Refactor 🔧
- [ ] Documentación 📚
- [ ] Otro

## ¿Cómo probar estos cambios?
1. Iniciar la aplicación normalmente.
2. Forzar un escenario donde el access token expire.
3. Provocar también un fallo en el refresh token.
4. Verificar que:
   - se ejecuta el logout correctamente,
   - la app no entra en doble navegación hacia `/auth/login`,
   - no se propaga el error al `errorInterceptor` en este flujo.
5. Validar que en producción la variable `apiUrl` apunte al valor configurado en `environment.prod.ts`.

## Checklist
- [x] El código compila y pasa los tests
- [ ] La documentación está actualizada (si aplica)
- [x] No hay warnings nuevos
- [x] Revisé el formato y convenciones de código

## Screenshots (si aplica)
No aplica.

## Issue relacionada
<!-- Si hay issues asociadas, referencia: closes #123 -->

## Notas para el revisor
- En `auth.interceptor.ts` se reemplaza `throwError(() => refreshError)` por `EMPTY` cuando falla el refresh token.
- Esto evita que el error continúe hacia `errorInterceptor`, que también redirige al login en respuestas `401`.
- Se actualizó `environment.prod.ts` para dejar preparada la URL base de la API de producción.
- Hay cambios adicionales en `angular.json` asociados a la configuración de producción.