### PR TITLE
feat(issue-30): corregir open redirect y mover tokens a sessionStorage 

### DIFF
--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -33,15 +33,15 @@ describe('AuthService', () => {
     service = TestBed.inject(AuthService);
     httpMock = TestBed.inject(HttpTestingController);
     routerSpy = TestBed.inject(Router) as unknown as typeof routerSpyObj;
-    localStorage.clear();
+    sessionStorage.clear();
   });
 
-  afterEach(() => { httpMock.verify(); localStorage.clear(); });
+  afterEach(() => { httpMock.verify(); sessionStorage.clear(); });
 
   describe('Login', () => {
     it('debe ser creado', () => { expect(service).toBeTruthy(); });
 
-    it('debe hacer login exitosamente y guardar datos en localStorage', async () => {
+    it('debe hacer login exitosamente y guardar datos en sessionStorage', async () => {
       const promise = lastValueFrom(service.login(mockLoginRequest));
       const req = httpMock.expectOne(r => r.url.includes('/auth/login'));
       expect(req.request.method).toBe('POST');
@@ -50,9 +50,9 @@ describe('AuthService', () => {
 
       const response = await promise;
       expect(response).toEqual(mockAuthResponse);
-      expect(localStorage.getItem('auth_token')).toBe(mockAuthResponse.accessToken);
-      expect(localStorage.getItem('refresh_token')).toBe(mockAuthResponse.refreshToken);
-      expect(localStorage.getItem('user_data')).toBe(JSON.stringify(mockAuthResponse.user));
+      expect(sessionStorage.getItem('auth_token')).toBe(mockAuthResponse.accessToken);
+      expect(sessionStorage.getItem('refresh_token')).toBe(mockAuthResponse.refreshToken);
+      expect(sessionStorage.getItem('user_data')).toBe(JSON.stringify(mockAuthResponse.user));
     });
 
     it('debe actualizar el currentUser$ al hacer login', async () => {
@@ -83,24 +83,24 @@ describe('AuthService', () => {
 
       const response = await promise;
       expect(response).toEqual(mockAuthResponse);
-      expect(localStorage.getItem('auth_token')).toBe(mockAuthResponse.accessToken);
+      expect(sessionStorage.getItem('auth_token')).toBe(mockAuthResponse.accessToken);
     });
   });
 
   describe('Logout', () => {
-    it('debe limpiar localStorage y redirigir al login', () => {
-      localStorage.setItem('auth_token', 'test-token');
-      localStorage.setItem('refresh_token', 'test-refresh');
-      localStorage.setItem('user_data', JSON.stringify({ id: '1' }));
+    it('debe limpiar sessionStorage y redirigir al login', () => {
+      sessionStorage.setItem('auth_token', 'test-token');
+      sessionStorage.setItem('refresh_token', 'test-refresh');
+      sessionStorage.setItem('user_data', JSON.stringify({ id: '1' }));
       service.logout();
-      expect(localStorage.getItem('auth_token')).toBeNull();
-      expect(localStorage.getItem('refresh_token')).toBeNull();
-      expect(localStorage.getItem('user_data')).toBeNull();
+      expect(sessionStorage.getItem('auth_token')).toBeNull();
+      expect(sessionStorage.getItem('refresh_token')).toBeNull();
+      expect(sessionStorage.getItem('user_data')).toBeNull();
       expect(routerSpy.navigate).toHaveBeenCalledWith(['/auth/login']);
     });
 
     it('debe actualizar currentUser$ a null tras logout', async () => {
-      localStorage.setItem('auth_token', 'test-token');
+      sessionStorage.setItem('auth_token', 'test-token');
       service.logout();
       const user = await firstValueFrom(service.currentUser$);
       expect(user).toBeNull();
@@ -108,20 +108,20 @@ describe('AuthService', () => {
   });
 
   describe('Token Management', () => {
-    it('getToken debe retornar el token del localStorage', () => {
-      localStorage.setItem('auth_token', 'test-token-123');
+    it('getToken debe retornar el token del sessionStorage', () => {
+      sessionStorage.setItem('auth_token', 'test-token-123');
       expect(service.getToken()).toBe('test-token-123');
     });
 
     it('getToken debe retornar null si no hay token', () => { expect(service.getToken()).toBeNull(); });
 
     it('getRefreshToken debe retornar el refresh token', () => {
-      localStorage.setItem('refresh_token', 'test-refresh-123');
+      sessionStorage.setItem('refresh_token', 'test-refresh-123');
       expect(service.getRefreshToken()).toBe('test-refresh-123');
     });
 
     it('isAuthenticated debe retornar true si hay token', () => {
-      localStorage.setItem('auth_token', 'test-token');
+      sessionStorage.setItem('auth_token', 'test-token');
       expect(service.isAuthenticated()).toBe(true);
     });
 
@@ -130,40 +130,40 @@ describe('AuthService', () => {
 
   describe('Token Expiration', () => {
     it('isTokenExpired debe retornar true si el token expiró', () => {
-      localStorage.setItem('auth_token', createMockToken(-10));
+      sessionStorage.setItem('auth_token', createMockToken(-10));
       expect(service.isTokenExpired()).toBe(true);
     });
 
     it('isTokenExpired debe retornar false si el token es válido', () => {
-      localStorage.setItem('auth_token', createMockToken(30));
+      sessionStorage.setItem('auth_token', createMockToken(30));
       expect(service.isTokenExpired()).toBe(false);
     });
 
     it('isTokenExpired debe retornar true si no hay token', () => { expect(service.isTokenExpired()).toBe(true); });
 
     it('isTokenExpired debe manejar tokens malformados', () => {
-      localStorage.setItem('auth_token', 'invalid-token');
+      sessionStorage.setItem('auth_token', 'invalid-token');
       expect(service.isTokenExpired()).toBe(true);
     });
 
     it('isTokenExpiringSoon debe retornar true si expira en menos de 5 minutos', () => {
-      localStorage.setItem('auth_token', createMockToken(3));
+      sessionStorage.setItem('auth_token', createMockToken(3));
       expect(service.isTokenExpiringSoon()).toBe(true);
     });
 
     it('isTokenExpiringSoon debe retornar false si expira en más de 5 minutos', () => {
-      localStorage.setItem('auth_token', createMockToken(10));
+      sessionStorage.setItem('auth_token', createMockToken(10));
       expect(service.isTokenExpiringSoon()).toBe(false);
     });
 
     it('isTokenExpiringSoon debe aceptar parámetro de minutos personalizado', () => {
-      localStorage.setItem('auth_token', createMockToken(8));
+      sessionStorage.setItem('auth_token', createMockToken(8));
       expect(service.isTokenExpiringSoon(10)).toBe(true);
       expect(service.isTokenExpiringSoon(5)).toBe(false);
     });
 
     it('getTokenExpirationTime debe retornar el tiempo restante en ms', () => {
-      localStorage.setItem('auth_token', createMockToken(5));
+      sessionStorage.setItem('auth_token', createMockToken(5));
       const time = service.getTokenExpirationTime();
       expect(time).not.toBeNull();
       expect(time!).toBeGreaterThan(0);
@@ -173,14 +173,14 @@ describe('AuthService', () => {
     it('getTokenExpirationTime debe retornar null si no hay token', () => { expect(service.getTokenExpirationTime()).toBeNull(); });
 
     it('getTokenExpirationTime debe retornar 0 si el token ya expiró', () => {
-      localStorage.setItem('auth_token', createMockToken(-10));
+      sessionStorage.setItem('auth_token', createMockToken(-10));
       expect(service.getTokenExpirationTime()).toBe(0);
     });
   });
 
   describe('Refresh Token', () => {
     it('debe refrescar el token exitosamente', async () => {
-      localStorage.setItem('refresh_token', 'old-refresh-token');
+      sessionStorage.setItem('refresh_token', 'old-refresh-token');
       const newAuthResponse: AuthResponse = { ...mockAuthResponse, accessToken: 'new-access-token', refreshToken: 'new-refresh-token' };
 
       const promise = lastValueFrom(service.refreshToken());
@@ -191,23 +191,23 @@ describe('AuthService', () => {
 
       const response = await promise;
       expect(response).toEqual(newAuthResponse);
-      expect(localStorage.getItem('auth_token')).toBe('new-access-token');
-      expect(localStorage.getItem('refresh_token')).toBe('new-refresh-token');
+      expect(sessionStorage.getItem('auth_token')).toBe('new-access-token');
+      expect(sessionStorage.getItem('refresh_token')).toBe('new-refresh-token');
     });
 
     it('debe limpiar datos si el refresh falla', async () => {
-      localStorage.setItem('auth_token', 'old-token');
-      localStorage.setItem('refresh_token', 'old-refresh');
-      localStorage.setItem('user_data', JSON.stringify({ id: '1' }));
+      sessionStorage.setItem('auth_token', 'old-token');
+      sessionStorage.setItem('refresh_token', 'old-refresh');
+      sessionStorage.setItem('user_data', JSON.stringify({ id: '1' }));
 
       const promise = lastValueFrom(service.refreshToken());
       const req = httpMock.expectOne(r => r.url.includes('/auth/refresh'));
       req.flush({ message: 'Invalid refresh token' }, { status: 401, statusText: 'Unauthorized' });
 
       await expect(promise).rejects.toBeDefined();
-      expect(localStorage.getItem('auth_token')).toBeNull();
-      expect(localStorage.getItem('refresh_token')).toBeNull();
-      expect(localStorage.getItem('user_data')).toBeNull();
+      expect(sessionStorage.getItem('auth_token')).toBeNull();
+      expect(sessionStorage.getItem('refresh_token')).toBeNull();
+      expect(sessionStorage.getItem('user_data')).toBeNull();
     });
 
     it('debe retornar error si no hay refresh token', async () => {
@@ -220,7 +220,7 @@ describe('AuthService', () => {
   describe('Get Current User', () => {
     it('debe retornar el usuario actual', () => {
       const user = { email: 'test@example.com', name: 'Test' };
-      localStorage.setItem('user_data', JSON.stringify(user));
+      sessionStorage.setItem('user_data', JSON.stringify(user));
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({
         providers: [AuthService, ApiService, provideHttpClient(), provideHttpClientTesting(), { provide: Router, useValue: { navigate: vi.fn() } }],

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -53,11 +53,11 @@ export class AuthService {
   }
 
   getToken(): string | null {
-    return this.isBrowser ? localStorage.getItem(this.TOKEN_KEY) : null;
+    return this.isBrowser ? sessionStorage.getItem(this.TOKEN_KEY) : null;
   }
 
   getRefreshToken(): string | null {
-    return this.isBrowser ? localStorage.getItem(this.REFRESH_TOKEN_KEY) : null;
+    return this.isBrowser ? sessionStorage.getItem(this.REFRESH_TOKEN_KEY) : null;
   }
 
   isAuthenticated(): boolean {
@@ -130,23 +130,23 @@ export class AuthService {
 
   private saveAuthData(response: AuthResponse): void {
     if (!this.isBrowser) return;
-    localStorage.setItem(this.TOKEN_KEY, response.accessToken);
+    sessionStorage.setItem(this.TOKEN_KEY, response.accessToken);
     if (response.refreshToken) {
-      localStorage.setItem(this.REFRESH_TOKEN_KEY, response.refreshToken);
+      sessionStorage.setItem(this.REFRESH_TOKEN_KEY, response.refreshToken);
     }
-    localStorage.setItem(this.USER_KEY, JSON.stringify(response.user));
+    sessionStorage.setItem(this.USER_KEY, JSON.stringify(response.user));
   }
 
   private clearAuthData(): void {
     if (!this.isBrowser) return;
-    localStorage.removeItem(this.TOKEN_KEY);
-    localStorage.removeItem(this.REFRESH_TOKEN_KEY);
-    localStorage.removeItem(this.USER_KEY);
+    sessionStorage.removeItem(this.TOKEN_KEY);
+    sessionStorage.removeItem(this.REFRESH_TOKEN_KEY);
+    sessionStorage.removeItem(this.USER_KEY);
   }
 
   private getUserFromStorage(): User | null {
     if (!this.isBrowser) return null;
-    const userStr = localStorage.getItem(this.USER_KEY);
+    const userStr = sessionStorage.getItem(this.USER_KEY);
     return userStr ? (JSON.parse(userStr) as User) : null;
   }
 }

--- a/src/app/core/utils/url.utils.spec.ts
+++ b/src/app/core/utils/url.utils.spec.ts
@@ -1,0 +1,30 @@
+import { sanitizeReturnUrl } from './url.utils';
+
+describe('sanitizeReturnUrl', () => {
+  it('retorna la URL si es una ruta relativa válida', () => {
+    expect(sanitizeReturnUrl('/app/dashboard')).toBe('/app/dashboard');
+    expect(sanitizeReturnUrl('/app/orders/123')).toBe('/app/orders/123');
+    expect(sanitizeReturnUrl('/auth/login')).toBe('/auth/login');
+  });
+
+  it('rechaza URLs externas absolutas', () => {
+    expect(sanitizeReturnUrl('https://evil.com')).toBe('/app/dashboard');
+    expect(sanitizeReturnUrl('http://evil.com/steal')).toBe('/app/dashboard');
+  });
+
+  it('rechaza URLs protocol-relative (//evil.com)', () => {
+    expect(sanitizeReturnUrl('//evil.com')).toBe('/app/dashboard');
+    expect(sanitizeReturnUrl('//evil.com/path')).toBe('/app/dashboard');
+  });
+
+  it('rechaza cadenas vacías y valores nulos', () => {
+    expect(sanitizeReturnUrl('')).toBe('/app/dashboard');
+    expect(sanitizeReturnUrl(null)).toBe('/app/dashboard');
+    expect(sanitizeReturnUrl(undefined)).toBe('/app/dashboard');
+  });
+
+  it('rechaza javascript: y data: URIs', () => {
+    expect(sanitizeReturnUrl('javascript:alert(1)')).toBe('/app/dashboard');
+    expect(sanitizeReturnUrl('data:text/html,<script>alert(1)</script>')).toBe('/app/dashboard');
+  });
+});

--- a/src/app/core/utils/url.utils.ts
+++ b/src/app/core/utils/url.utils.ts
@@ -1,9 +1,9 @@
 const DEFAULT_RETURN_URL = '/app/dashboard';
 
 /**
- * Validates that a returnUrl is a safe internal path to prevent open-redirect attacks.
- * Accepts only relative paths starting with a single "/" — rejects external URLs,
- * protocol-relative URLs (//evil.com), and anything else that could redirect off-site.
+ * Función para sanitizar URLs de retorno, asegurando que sean rutas internas seguras.
+ * @param url La URL a sanitizar.
+ * @returns Una URL interna segura o la URL de retorno predeterminada.
  */
 export function sanitizeReturnUrl(url: string | undefined | null): string {
   if (!url) return DEFAULT_RETURN_URL;

--- a/src/app/core/utils/url.utils.ts
+++ b/src/app/core/utils/url.utils.ts
@@ -1,0 +1,12 @@
+const DEFAULT_RETURN_URL = '/app/dashboard';
+
+/**
+ * Validates that a returnUrl is a safe internal path to prevent open-redirect attacks.
+ * Accepts only relative paths starting with a single "/" — rejects external URLs,
+ * protocol-relative URLs (//evil.com), and anything else that could redirect off-site.
+ */
+export function sanitizeReturnUrl(url: string | undefined | null): string {
+  if (!url) return DEFAULT_RETURN_URL;
+  const safe = url.startsWith('/') && !url.startsWith('//');
+  return safe ? url : DEFAULT_RETURN_URL;
+}

--- a/src/app/modules/public/auth/login/login.component.ts
+++ b/src/app/modules/public/auth/login/login.component.ts
@@ -20,6 +20,7 @@ import {
 import { firstValueFrom } from 'rxjs';
 import { toast } from 'ngx-sonner';
 import { AuthService } from '../../../../core/services/auth.service';
+import { sanitizeReturnUrl } from '../../../../core/utils/url.utils';
 import { AnimatedPetComponent } from '../../../../shared/animated-pet/animated-pet.component';
 
 @Component({
@@ -39,8 +40,9 @@ export class LoginComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
-  private readonly returnUrl =
-    this.route.snapshot.queryParams['returnUrl'] ?? '/app/dashboard';
+  private readonly returnUrl = sanitizeReturnUrl(
+    this.route.snapshot.queryParams['returnUrl'],
+  );
 
   isPasswordFocused = false;
   isEmailFocused = false;

--- a/src/app/modules/public/auth/register/register.component.ts
+++ b/src/app/modules/public/auth/register/register.component.ts
@@ -38,6 +38,7 @@ import {
   Observable,
 } from 'rxjs';
 import { AuthResponse } from '../models/auth.model';
+import { sanitizeReturnUrl } from '../../../../core/utils/url.utils';
 
 /**
  * Componente de Registro
@@ -203,8 +204,7 @@ export class RegisterComponent implements OnInit, OnDestroy {
    * @returns void
    */
   private getReturnUrl(): void {
-    const urlParam = this.route.snapshot.queryParams['returnUrl'];
-    this.returnUrl = urlParam || '/app/dashboard';
+    this.returnUrl = sanitizeReturnUrl(this.route.snapshot.queryParams['returnUrl']);
   }
 
   /**


### PR DESCRIPTION
[# 🚀 Pull Request

## Descripción
Se actualiza el manejo de autenticación para almacenar la sesión en `sessionStorage` en lugar de `localStorage`, y se agrega una utilidad para sanitizar la `returnUrl` usada en los flujos de login y registro.

Con esto se mejora el control del ciclo de vida de la sesión en navegador y se endurece la navegación de retorno evitando redirecciones inseguras hacia URLs externas o malformadas.

## ¿Qué tipo de cambio es?
- [x] Bugfix 🐞
- [ ] Feature ✨
- [ ] Refactor 🔧
- [ ] Documentación 📚
- [ ] Otro

## ¿Cómo probar estos cambios?
1. Levantar la aplicación.
2. Iniciar sesión con credenciales válidas.
3. Verificar en DevTools que:
   - `auth_token`,
   - `refresh_token`,
   - `user_data`
   se guarden en `sessionStorage` y no en `localStorage`.
4. Recargar la pestaña y validar el comportamiento esperado de la sesión.
5. Cerrar la pestaña/sesión del navegador según el flujo esperado y confirmar que los datos no persistan fuera de la sesión actual.
6. Ejecutar logout y verificar que:
   - se limpien los valores de `sessionStorage`,
   - se redirija a `/auth/login`.
7. Probar login o register con `returnUrl` válidas, por ejemplo:
   - `/app/dashboard`
   - `/app/orders/123`
8. Probar login o register con `returnUrl` inválidas o inseguras, por ejemplo:
   - `https://evil.com`
   - `//evil.com`
   - `javascript:alert(1)`
   - `data:text/html,<script>alert(1)</script>`
9. Confirmar que en esos casos la navegación use `/app/dashboard` como fallback seguro.
10. Ejecutar los tests de `AuthService` y de `url.utils`.

## Checklist
- [x] El código compila y pasa los tests
- [ ] La documentación está actualizada (si aplica)
- [x] No hay warnings nuevos
- [x] Revisé el formato y convenciones de código

## Screenshots (si aplica)
No aplica.

## Issue relacionada
<!-- Si hay issues asociadas, referencia: closes #123 -->

## Notas para el revisor
- `AuthService` ahora persiste `auth_token`, `refresh_token` y `user_data` en `sessionStorage`.
- Se ajustaron `getToken()`, `getRefreshToken()`, `saveAuthData()`, `clearAuthData()` y `getUserFromStorage()` para trabajar con `sessionStorage`.
- Se agregó `sanitizeReturnUrl()` en `src/app/core/utils/url.utils.ts`.
- La sanitización permite únicamente rutas internas relativas seguras.
- `login.component.ts` y `register.component.ts` ahora usan `sanitizeReturnUrl()` para resolver la navegación posterior a autenticación.
- Se añadieron tests unitarios para cubrir casos válidos e inválidos de `returnUrl`.
- También se actualizaron los tests de `AuthService` para reflejar el cambio de almacenamiento de `localStorage` a `sessionStorage`.](http://localhost:4200/app/dashboard)