### PR TITLE
refactor(issue-33): migrar estado plano a signals y eliminar JSDoc 

### DIFF
--- a/src/app/modules/private/employees/modals/employee-create-edit-modal/employee-create-edit-modal.component.ts
+++ b/src/app/modules/private/employees/modals/employee-create-edit-modal/employee-create-edit-modal.component.ts
@@ -25,12 +25,6 @@ import {
 import { EmployeesService } from '../../services/employees.service';
 import { toast } from 'ngx-sonner';
 
-/**
- * Modal para crear o editar un empleado usando Signal Forms (Angular 21)
- *
- * @since 2026-05-10
- * @author Bunnystring
- */
 @Component({
   selector: 'app-employee-create-edit-modal',
   templateUrl: './employee-create-edit-modal.component.html',

--- a/src/app/modules/private/groups/modals/group-create-edit-modal/group-create-edit-modal.component.ts
+++ b/src/app/modules/private/groups/modals/group-create-edit-modal/group-create-edit-modal.component.ts
@@ -19,12 +19,6 @@ import { Group, GroupFormResult } from '../../models/groups.model';
 import { GroupsService } from '../../services/groups.service';
 import { toast } from 'ngx-sonner';
 
-/**
- * Modal para crear o editar un grupo usando Signal Forms (Angular 21)
- *
- * @since 2026-05-11
- * @author Bunnystring
- */
 @Component({
   selector: 'app-group-create-edit-modal',
   templateUrl: './group-create-edit-modal.component.html',

--- a/src/app/modules/public/auth/login/login.component.html
+++ b/src/app/modules/public/auth/login/login.component.html
@@ -2,8 +2,8 @@
   <div class="card-body">
     <!-- Mascota animada -->
     <app-animated-pet
-      [isPasswordFocused]="isPasswordFocused"
-      [isTextFieldFocused]="isEmailFocused"
+      [isPasswordFocused]="isPasswordFocused()"
+      [isTextFieldFocused]="isEmailFocused()"
       [textFieldValue]="loginForm.email().value()"
       [focusedFieldType]="'email'">
     </app-animated-pet>

--- a/src/app/modules/public/auth/login/login.component.ts
+++ b/src/app/modules/public/auth/login/login.component.ts
@@ -44,8 +44,8 @@ export class LoginComponent {
     this.route.snapshot.queryParams['returnUrl'],
   );
 
-  isPasswordFocused = false;
-  isEmailFocused = false;
+  readonly isPasswordFocused = signal(false);
+  readonly isEmailFocused = signal(false);
   private isTogglingPassword = false;
 
   readonly showPassword = signal(false);
@@ -110,18 +110,18 @@ export class LoginComponent {
   }
 
   onEmailFocus(): void {
-    this.isPasswordFocused = false;
-    this.isEmailFocused = true;
+    this.isPasswordFocused.set(false);
+    this.isEmailFocused.set(true);
   }
 
   onEmailBlur(): void {
-    this.isEmailFocused = false;
+    this.isEmailFocused.set(false);
     if (this.mascot) this.mascot.resetEyePosition();
   }
 
   onPasswordAreaFocus(): void {
-    this.isPasswordFocused = true;
-    this.isEmailFocused = false;
+    this.isPasswordFocused.set(true);
+    this.isEmailFocused.set(false);
   }
 
   onPasswordAreaBlur(event: FocusEvent): void {
@@ -129,7 +129,7 @@ export class LoginComponent {
     const relatedTarget = event.relatedTarget as HTMLElement;
     const currentTarget = event.currentTarget as HTMLElement;
     if (relatedTarget && currentTarget.contains(relatedTarget)) return;
-    this.isPasswordFocused = false;
+    this.isPasswordFocused.set(false);
   }
 
   onRememberMeChange(event: Event): void {


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción
Se realizan ajustes menores de limpieza y consistencia en componentes de autenticación y modales, alineando el uso de estado reactivo con señales en el login y eliminando bloques de documentación redundantes en modales.

Los cambios principales incluyen:
- migración de `isPasswordFocused` e `isEmailFocused` en `LoginComponent` de booleanos tradicionales a `signal<boolean>`,
- actualización del template de login para consumir correctamente esos estados reactivos con `isPasswordFocused()` e `isEmailFocused()`,
- ajuste de los handlers de focus/blur para usar `.set(...)` sobre señales,
- eliminación de comentarios de encabezado redundantes en los modales de creación/edición de empleados y grupos.

## ¿Qué tipo de cambio es?
- [ ] Bugfix 🐞
- [ ] Feature ✨
- [x] Refactor 🔧
- [ ] Documentación 📚
- [ ] Otro

## ¿Cómo probar estos cambios?
1. Levantar la aplicación.
2. Ir a la pantalla de login.
3. Verificar que la mascota animada siga reaccionando correctamente a:
   - foco en el campo de email,
   - blur del campo de email,
   - foco en el área de contraseña,
   - blur del área de contraseña,
   - interacción con mostrar/ocultar contraseña.
4. Confirmar que:
   - `isPasswordFocused()` actualice correctamente el estado visual esperado,
   - `isEmailFocused()` actualice correctamente el estado visual esperado,
   - no haya errores de template por acceso incorrecto a señales.
5. Navegar a los modales de crear/editar empleado y grupo para confirmar que no hubo impacto funcional por la limpieza de comentarios.

## Checklist
- [x] El código compila y pasa los tests
- [ ] La documentación está actualizada (si aplica)
- [x] No hay warnings nuevos
- [x] Revisé el formato y convenciones de código

## Screenshots (si aplica)
No aplica.

## Issue relacionada
<!-- Si hay issues asociadas, referencia: closes #123 -->

## Notas para el revisor
- El cambio funcional principal está en `LoginComponent`.
- Se reemplazó estado booleano mutable por señales para mantener consistencia con el resto del proyecto.
- El template fue ajustado para invocar correctamente las señales en bindings.
- Los cambios en modales de empleados y grupos son solo de limpieza de comentarios, sin impacto en lógica.