### PR TITLE
Merge Main to Dev

### DIFF
--- a/src/app/modules/private/devices/pages/devices-detail/devices-detail.component.spec.ts
+++ b/src/app/modules/private/devices/pages/devices-detail/devices-detail.component.spec.ts
@@ -1,23 +1,199 @@
-import { TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
-import { provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { Location } from '@angular/common';
+import { Router, ActivatedRoute, provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
 import { DevicesDetailComponent } from './devices-detail.component';
+import { DevicesService } from '../../services/devices.service';
+import { OrdersService } from '../../../orders/services/orders.service';
+import { LoadingService } from '../../../../../core/services/loading.service';
+import { Device, DeviceAssignment, DeviceStatus } from '../../models/device.model';
+import { Order, OrderStates } from '../../../orders/models/orders.model';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+const mockDevice: Device = {
+  id: 'dev-1',
+  name: 'Laptop HP',
+  brand: 'HP',
+  barcode: 'HP001',
+  status: DeviceStatus.GOOD_CONDITION,
+  createdAt: '2026-01-01T00:00:00',
+  updatedAt: null,
+};
+
+const mockAssignment: DeviceAssignment = {
+  deviceId: 'dev-1',
+  orderId: 'ord-1',
+  deviceName: 'Laptop HP',
+  deviceStatus: DeviceStatus.GOOD_CONDITION,
+  assignedAt: '2026-01-01T00:00:00',
+};
+
+const mockOrder: Order = {
+  id: 'ord-1',
+  description: 'Orden de prueba',
+  state: OrderStates.CREATED,
+  assigneeType: 'EMPLOYEE',
+  assigneeId: 'emp-1',
+  createdAt: '2026-01-01T00:00:00',
+  updatedAt: '2026-01-01T00:00:00',
+  items: [],
+  assignee: null,
+};
+
+function buildProviders(
+  deviceId = 'dev-1',
+  deviceResult: Device | null = mockDevice,
+  assignments: DeviceAssignment[] = [mockAssignment],
+  orderResult: Order | null = mockOrder,
+) {
+  const devicesServiceSpy = {
+    getDeviceById: () =>
+      deviceResult ? of(deviceResult) : throwError(() => ({ error: { message: 'Not found' } })),
+    getDeviceAssignmentHistory: () => of(assignments),
+  };
+  const ordersServiceSpy = {
+    getOrderById: () =>
+      orderResult ? of(orderResult) : throwError(() => new Error('Not found')),
+  };
+
+  return [
+    provideRouter([]),
+    { provide: DevicesService, useValue: devicesServiceSpy },
+    { provide: OrdersService, useValue: ordersServiceSpy },
+    { provide: LoadingService, useValue: { loading$: of(false) } },
+    { provide: ActivatedRoute, useValue: { params: of({ id: deviceId }) } },
+  ];
+}
 
 describe('DevicesDetailComponent', () => {
-  beforeEach(async () => {
+  let component: DevicesDetailComponent;
+  let fixture: ComponentFixture<DevicesDetailComponent>;
+  let locationSpy: { back: ReturnType<typeof vi.fn> };
+  let router: Router;
+
+  async function setup(
+    deviceId = 'dev-1',
+    deviceResult: Device | null = mockDevice,
+    assignments: DeviceAssignment[] = [mockAssignment],
+    orderResult: Order | null = mockOrder,
+  ) {
+    locationSpy = { back: vi.fn() };
+
     await TestBed.configureTestingModule({
       imports: [DevicesDetailComponent],
       providers: [
-        provideRouter([]),
-        provideHttpClient(),
-        provideHttpClientTesting(),
+        ...buildProviders(deviceId, deviceResult, assignments, orderResult),
+        { provide: Location, useValue: locationSpy },
       ],
     }).compileComponents();
+
+    fixture = TestBed.createComponent(DevicesDetailComponent);
+    component = fixture.componentInstance;
+    router = TestBed.inject(Router);
+    await fixture.whenStable();
+    await fixture.whenStable();
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  // ── Creación ──────────────────────────────────────────────────────────────
+  it('debe ser creado', async () => {
+    await setup();
+    expect(component).toBeTruthy();
   });
 
-  it('should create', () => {
-    const fixture = TestBed.createComponent(DevicesDetailComponent);
-    expect(fixture.componentInstance).toBeTruthy();
+  // ── getShortId ────────────────────────────────────────────────────────────
+  describe('getShortId', () => {
+    it('retorna los primeros 8 caracteres del id', async () => {
+      await setup();
+      expect(component.getShortId('ord-12345-full')).toBe('ord-1234');
+    });
+
+    it('retorna el string completo si tiene menos de 8 chars', async () => {
+      await setup();
+      expect(component.getShortId('abc')).toBe('abc');
+    });
+  });
+
+  // ── goBack ────────────────────────────────────────────────────────────────
+  describe('goBack', () => {
+    it('llama a location.back()', async () => {
+      await setup();
+      component.goBack();
+      expect(locationSpy.back).toHaveBeenCalled();
+    });
+  });
+
+  // ── goDetailOrder ─────────────────────────────────────────────────────────
+  describe('goDetailOrder', () => {
+    it('navega al detalle de la orden', async () => {
+      await setup();
+      const navigateSpy = vi.spyOn(router, 'navigate');
+      component.goDetailOrder('ord-1');
+      expect(navigateSpy).toHaveBeenCalledWith(['/app/orders/', 'ord-1']);
+    });
+
+    it('no navega si orderId está vacío', async () => {
+      await setup();
+      const navigateSpy = vi.spyOn(router, 'navigate');
+      component.goDetailOrder('');
+      expect(navigateSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── refreshData ───────────────────────────────────────────────────────────
+  describe('refreshData', () => {
+    it('llama a initParams', async () => {
+      await setup();
+      const spy = vi.spyOn(component, 'initParams');
+      component.refreshData();
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  // ── initParams — carga exitosa ────────────────────────────────────────────
+  describe('initParams', () => {
+    it('carga el dispositivo correctamente', async () => {
+      await setup();
+      expect(component.device()).toBeTruthy();
+      expect(component.device()?.id).toBe('dev-1');
+    });
+
+    it('enriquece las asignaciones con el nombre de la orden', async () => {
+      await setup();
+      const assignments = component.deviceAssignments();
+      expect(assignments.length).toBe(1);
+      expect(assignments[0].orderName).toBe(mockOrder.description);
+    });
+
+    it('marca orderFound true cuando la orden existe', async () => {
+      await setup();
+      expect(component.deviceAssignments()[0].orderFound).toBe(true);
+    });
+
+    it('establece error cuando el dispositivo no existe', async () => {
+      await setup('bad-id', null);
+      expect(component.error()).toBeTruthy();
+    });
+
+    it('maneja historial de asignaciones vacío', async () => {
+      await setup('dev-1', mockDevice, []);
+      expect(component.device()).toBeTruthy();
+      expect(component.deviceAssignments()).toEqual([]);
+    });
+
+    it('maneja error en la orden de una asignación sin romper', async () => {
+      await setup('dev-1', mockDevice, [mockAssignment], null);
+      expect(component.device()).toBeTruthy();
+      const assignments = component.deviceAssignments();
+      expect(assignments.length).toBe(1);
+      expect(assignments[0].orderFound).toBe(false);
+    });
+
+    it('asignación sin orderId no llama a getOrderById', async () => {
+      const assignmentWithoutOrder: DeviceAssignment = { ...mockAssignment, orderId: '' };
+      await setup('dev-1', mockDevice, [assignmentWithoutOrder], mockOrder);
+      expect(component.device()).toBeTruthy();
+    });
   });
 });

--- a/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.spec.ts
+++ b/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.spec.ts
@@ -94,7 +94,7 @@ describe('OrderCreateEditModalComponent', () => {
 
     fixture = TestBed.createComponent(OrderCreateEditModalComponent);
     component = fixture.componentInstance;
-    if (order) component.order = order;
+    if (order) fixture.componentRef.setInput('order', order);
     await fixture.whenStable();
     await fixture.whenStable();
   }
@@ -313,7 +313,7 @@ describe('OrderCreateEditModalComponent', () => {
 
       fixture = TestBed.createComponent(OrderCreateEditModalComponent);
       component = fixture.componentInstance;
-      component.order = mockOrder;
+      fixture.componentRef.setInput('order', mockOrder);
       await fixture.whenStable();
       await fixture.whenStable();
 
@@ -356,7 +356,7 @@ describe('OrderCreateEditModalComponent', () => {
       component.onSubmit();
       await fixture.whenStable();
 
-      expect(component.formError).toBe('Error del servidor');
+      expect(component.formError()).toBe('Error del servidor');
     });
   });
 
@@ -364,7 +364,7 @@ describe('OrderCreateEditModalComponent', () => {
   describe('onAssignedTypeChange', () => {
     it('limpia assigneeId al cambiar el tipo de asignación', async () => {
       await setup(mockOrder);
-      component.onAssignedTypeChange({});
+      component.onAssignedTypeChange();
       expect(component.orderForm.get('assigneeId')?.value).toBe('');
     });
   });
@@ -382,17 +382,17 @@ describe('OrderCreateEditModalComponent', () => {
   describe('estado inicial', () => {
     it('submitted inicia en false', async () => {
       await setup();
-      expect(component.submitted).toBe(false);
+      expect(component.submitted()).toBe(false);
     });
 
     it('formLoading inicia en false', async () => {
       await setup();
-      expect(component.formLoading).toBe(false);
+      expect(component.formLoading()).toBe(false);
     });
 
     it('formError inicia como cadena vacía', async () => {
       await setup();
-      expect(component.formError).toBe('');
+      expect(component.formError()).toBe('');
     });
   });
 });

--- a/src/app/modules/private/orders/modals/order-delete-modal/order-delete-modal.component.spec.ts
+++ b/src/app/modules/private/orders/modals/order-delete-modal/order-delete-modal.component.spec.ts
@@ -34,33 +34,33 @@ describe('OrderDeleteModalComponent', () => {
 
   // ── Estado inicial ────────────────────────────────────────────────────────
   it('loading inicia en false', () => {
-    expect(component.loading).toBe(false);
+    expect(component.loading()).toBe(false);
   });
 
   it('error inicia como cadena vacía', () => {
-    expect(component.error).toBe('');
+    expect(component.error()).toBe('');
   });
 
   it('order inicia en null sin @Input', () => {
-    expect(component.order).toBeNull();
+    expect(component.order()).toBeNull();
   });
 
-  // ── @Input order ──────────────────────────────────────────────────────────
-  describe('@Input order', () => {
-    it('refleja la orden asignada por Input', async () => {
-      component.order = mockOrder;
+  // ── input order ───────────────────────────────────────────────────────────
+  describe('input order', () => {
+    it('refleja la orden asignada por input', async () => {
+      fixture.componentRef.setInput('order', mockOrder);
       await fixture.whenStable();
-      expect(component.order).toEqual(mockOrder);
+      expect(component.order()).toEqual(mockOrder);
     });
 
     it('expone la descripción de la orden asignada', () => {
-      component.order = mockOrder;
-      expect(component.order?.description).toBe('Instalación de equipos banco');
+      fixture.componentRef.setInput('order', mockOrder);
+      expect(component.order()?.description).toBe('Instalación de equipos banco');
     });
 
-    it('acepta null como valor de @Input', () => {
-      component.order = null;
-      expect(component.order).toBeNull();
+    it('acepta null como valor de input', () => {
+      fixture.componentRef.setInput('order', null);
+      expect(component.order()).toBeNull();
     });
   });
 
@@ -79,25 +79,14 @@ describe('OrderDeleteModalComponent', () => {
     });
   });
 
-  // ── confirmDelete ─────────────────────────────────────────────────────────
-  describe('confirmDelete', () => {
-    it('existe el método confirmDelete', () => {
-      expect(component.confirmDelete).toBeDefined();
-    });
-
-    it('se puede invocar sin errores', () => {
-      expect(() => component.confirmDelete()).not.toThrow();
-    });
-  });
-
   // ── @Output events ────────────────────────────────────────────────────────
   describe('@Output events', () => {
-    it('deleted es un EventEmitter', () => {
+    it('deleted es un OutputEmitter', () => {
       expect(component.deleted).toBeDefined();
       expect(typeof component.deleted.emit).toBe('function');
     });
 
-    it('cancel es un EventEmitter', () => {
+    it('cancel es un OutputEmitter', () => {
       expect(component.cancel).toBeDefined();
       expect(typeof component.cancel.emit).toBe('function');
     });

--- a/src/app/modules/private/orders/pages/orders-detail/orders-detail.component.spec.ts
+++ b/src/app/modules/private/orders/pages/orders-detail/orders-detail.component.spec.ts
@@ -233,13 +233,13 @@ describe('OrdersDetailComponent', () => {
   describe('groupNameTooltip', () => {
     it('retorna cadena vacía cuando groupName está vacío', async () => {
       await setup();
-      component.groupName = '';
+      component.groupName.set('');
       expect(component.groupNameTooltip).toBe('');
     });
 
     it('retorna el tooltip con el nombre del grupo', async () => {
       await setup();
-      component.groupName = 'Grupo TI';
+      component.groupName.set('Grupo TI');
       expect(component.groupNameTooltip).toBe('Grupo: Grupo TI');
     });
   });
@@ -247,7 +247,7 @@ describe('OrdersDetailComponent', () => {
   describe('employeeNameTooltip', () => {
     it('retorna cadena vacía cuando no hay orden', async () => {
       await setup(undefined, null);
-      component.order = null;
+      component.order.set(null);
       expect(component.employeeNameTooltip).toBe('');
     });
   });
@@ -256,19 +256,19 @@ describe('OrdersDetailComponent', () => {
   describe('getOrderDetail', () => {
     it('carga la orden correctamente desde la ruta', async () => {
       await setup();
-      expect(component.order).toBeTruthy();
-      expect(component.order?.id).toBe(mockOrder.id);
+      expect(component.order()).toBeTruthy();
+      expect(component.order()?.id).toBe(mockOrder.id);
     });
 
     it('establece error cuando la orden no existe', async () => {
       await setup('bad-id', null);
-      expect(component.error).toBeTruthy();
-      expect(component.order).toBeNull();
+      expect(component.error()).toBeTruthy();
+      expect(component.order()).toBeNull();
     });
 
     it('carga dispositivos al obtener la orden con items', async () => {
       await setup();
-      expect(component.order?.items).toBeDefined();
+      expect(component.order()?.items).toBeDefined();
     });
   });
 
@@ -304,18 +304,10 @@ describe('OrdersDetailComponent', () => {
 
     it('no navega si no hay orden', async () => {
       await setup();
-      component.order = null;
+      component.order.set(null);
       const navigateSpy = vi.spyOn(router, 'navigate');
       component.goAsignedDetail();
       expect(navigateSpy).not.toHaveBeenCalled();
-    });
-  });
-
-  // ── ngOnDestroy ───────────────────────────────────────────────────────────
-  describe('ngOnDestroy', () => {
-    it('completa el subject destroy$ sin errores', async () => {
-      await setup();
-      expect(() => component.ngOnDestroy()).not.toThrow();
     });
   });
 });

--- a/src/app/modules/public/auth/login/login.component.spec.ts
+++ b/src/app/modules/public/auth/login/login.component.spec.ts
@@ -1,30 +1,157 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
-import { provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
-
+import { of, throwError } from 'rxjs';
 import { LoginComponent } from './login.component';
+import { AuthService } from '../../../../core/services/auth.service';
+import { AuthResponse } from '../models/auth.model';
+
+const mockAuthResponse: AuthResponse = {
+  accessToken: 'token-abc',
+  refreshToken: 'refresh-abc',
+  user: { email: 'test@test.com', name: 'Test' },
+};
+
+function buildProviders(
+  loginResult: 'success' | 'error' = 'success',
+) {
+  const authServiceSpy = {
+    isAuthenticated: vi.fn().mockReturnValue(false),
+    login: vi.fn().mockReturnValue(
+      loginResult === 'success'
+        ? of(mockAuthResponse)
+        : throwError(() => ({ error: { message: 'Credenciales inválidas' } })),
+    ),
+  };
+  return { authServiceSpy, providers: [{ provide: AuthService, useValue: authServiceSpy }] };
+}
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
   let fixture: ComponentFixture<LoginComponent>;
 
-  beforeEach(async () => {
+  async function setup(loginResult: 'success' | 'error' = 'success') {
+    const { providers } = buildProviders(loginResult);
     await TestBed.configureTestingModule({
       imports: [LoginComponent],
       providers: [
         provideRouter([]),
-        provideHttpClient(),
-        provideHttpClientTesting(),
+        ...providers,
       ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(LoginComponent);
     component = fixture.componentInstance;
     await fixture.whenStable();
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  // ── Creación ──────────────────────────────────────────────────────────────
+  it('debe ser creado', async () => {
+    await setup();
+    expect(component).toBeTruthy();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  // ── Estado inicial de signals ─────────────────────────────────────────────
+  describe('estado inicial', () => {
+    it('showPassword inicia en false', async () => {
+      await setup();
+      expect(component.showPassword()).toBe(false);
+    });
+
+    it('loading inicia en false', async () => {
+      await setup();
+      expect(component.loading()).toBe(false);
+    });
+
+    it('isPasswordFocused inicia en false', async () => {
+      await setup();
+      expect(component.isPasswordFocused()).toBe(false);
+    });
+
+    it('isEmailFocused inicia en false', async () => {
+      await setup();
+      expect(component.isEmailFocused()).toBe(false);
+    });
+  });
+
+  // ── Gestión de foco ───────────────────────────────────────────────────────
+  describe('gestión de foco', () => {
+    it('onEmailFocus activa isEmailFocused y desactiva isPasswordFocused', async () => {
+      await setup();
+      component.onPasswordAreaFocus();
+      component.onEmailFocus();
+      expect(component.isEmailFocused()).toBe(true);
+      expect(component.isPasswordFocused()).toBe(false);
+    });
+
+    it('onEmailBlur desactiva isEmailFocused', async () => {
+      await setup();
+      component.onEmailFocus();
+      component.onEmailBlur();
+      expect(component.isEmailFocused()).toBe(false);
+    });
+
+    it('onPasswordAreaFocus activa isPasswordFocused y desactiva isEmailFocused', async () => {
+      await setup();
+      component.onEmailFocus();
+      component.onPasswordAreaFocus();
+      expect(component.isPasswordFocused()).toBe(true);
+      expect(component.isEmailFocused()).toBe(false);
+    });
+
+    it('onPasswordAreaBlur desactiva isPasswordFocused si el foco sale del área', async () => {
+      await setup();
+      component.onPasswordAreaFocus();
+      const fakeEvent = { relatedTarget: null, currentTarget: document.createElement('div') } as unknown as FocusEvent;
+      component.onPasswordAreaBlur(fakeEvent);
+      expect(component.isPasswordFocused()).toBe(false);
+    });
+
+    it('onPasswordAreaBlur mantiene foco si relatedTarget está dentro del área', async () => {
+      await setup();
+      component.onPasswordAreaFocus();
+      const parent = document.createElement('div');
+      const child = document.createElement('button');
+      parent.appendChild(child);
+      const fakeEvent = { relatedTarget: child, currentTarget: parent } as unknown as FocusEvent;
+      component.onPasswordAreaBlur(fakeEvent);
+      expect(component.isPasswordFocused()).toBe(true);
+    });
+  });
+
+  // ── togglePasswordVisibility ──────────────────────────────────────────────
+  describe('togglePasswordVisibility', () => {
+    it('cambia showPassword de false a true', async () => {
+      await setup();
+      expect(component.showPassword()).toBe(false);
+      component.togglePasswordVisibility();
+      expect(component.showPassword()).toBe(true);
+    });
+
+    it('cambia showPassword de true a false', async () => {
+      await setup();
+      component.togglePasswordVisibility();
+      component.togglePasswordVisibility();
+      expect(component.showPassword()).toBe(false);
+    });
+  });
+
+  // ── resetForm ─────────────────────────────────────────────────────────────
+  describe('resetForm', () => {
+    it('limpia email y password del modelo', async () => {
+      await setup();
+      component.loginModel.update((m) => ({ ...m, email: 'a@b.com', password: '123456' }));
+      component.resetForm();
+      expect(component.loginModel().email).toBe('');
+      expect(component.loginModel().password).toBe('');
+    });
+
+    it('pone rememberMe en false', async () => {
+      await setup();
+      component.loginModel.update((m) => ({ ...m, rememberMe: true }));
+      component.resetForm();
+      expect(component.loginModel().rememberMe).toBe(false);
+    });
   });
 });

--- a/src/app/modules/public/auth/register/register.component.spec.ts
+++ b/src/app/modules/public/auth/register/register.component.spec.ts
@@ -2,29 +2,273 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-
 import { RegisterComponent } from './register.component';
+import { AuthService } from '../../../../core/services/auth.service';
+
+function buildProviders() {
+  const authServiceSpy = {
+    isAuthenticated: vi.fn().mockReturnValue(false),
+    register: vi.fn(),
+  };
+  return { authServiceSpy, providers: [{ provide: AuthService, useValue: authServiceSpy }] };
+}
 
 describe('RegisterComponent', () => {
   let component: RegisterComponent;
   let fixture: ComponentFixture<RegisterComponent>;
 
-  beforeEach(async () => {
+  async function setup() {
+    const { providers } = buildProviders();
     await TestBed.configureTestingModule({
       imports: [RegisterComponent],
       providers: [
         provideRouter([]),
         provideHttpClient(),
         provideHttpClientTesting(),
+        ...providers,
       ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(RegisterComponent);
     component = fixture.componentInstance;
+    fixture.detectChanges();
     await fixture.whenStable();
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  // ── Creación ──────────────────────────────────────────────────────────────
+  it('debe ser creado', async () => {
+    await setup();
+    expect(component).toBeTruthy();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  // ── Inicialización del formulario ─────────────────────────────────────────
+  describe('initForm', () => {
+    it('crea el formulario con los controles requeridos', async () => {
+      await setup();
+      expect(component.registerForm.contains('name')).toBe(true);
+      expect(component.registerForm.contains('email')).toBe(true);
+      expect(component.registerForm.contains('password')).toBe(true);
+      expect(component.registerForm.contains('confirmPassword')).toBe(true);
+    });
+
+    it('formulario es inválido cuando está vacío', async () => {
+      await setup();
+      expect(component.registerForm.invalid).toBe(true);
+    });
+
+    it('formulario es válido con datos correctos', async () => {
+      await setup();
+      component.registerForm.setValue({
+        name: 'Juan Pérez',
+        email: 'juan@test.com',
+        password: 'Password1!',
+        confirmPassword: 'Password1!',
+      });
+      expect(component.registerForm.valid).toBe(true);
+    });
+
+    it('invalida si las contraseñas no coinciden', async () => {
+      await setup();
+      component.registerForm.setValue({
+        name: 'Juan Pérez',
+        email: 'juan@test.com',
+        password: 'Password1!',
+        confirmPassword: 'OtraPassword1!',
+      });
+      expect(component.registerForm.invalid).toBe(true);
+    });
+  });
+
+  // ── Estado inicial de signals ─────────────────────────────────────────────
+  describe('estado inicial de signals', () => {
+    it('loading inicia en false', async () => {
+      await setup();
+      expect(component.loading()).toBe(false);
+    });
+
+    it('submitted inicia en false', async () => {
+      await setup();
+      expect(component.submitted()).toBe(false);
+    });
+
+    it('error inicia vacío', async () => {
+      await setup();
+      expect(component.error()).toBe('');
+    });
+
+    it('showPassword inicia en false', async () => {
+      await setup();
+      expect(component.showPassword()).toBe(false);
+    });
+
+    it('showConfirmPassword inicia en false', async () => {
+      await setup();
+      expect(component.showConfirmPassword()).toBe(false);
+    });
+
+    it('isPasswordFocused inicia en false', async () => {
+      await setup();
+      expect(component.isPasswordFocused()).toBe(false);
+    });
+
+    it('isEmailFocused inicia en false', async () => {
+      await setup();
+      expect(component.isEmailFocused()).toBe(false);
+    });
+
+    it('isNameFocused inicia en false', async () => {
+      await setup();
+      expect(component.isNameFocused()).toBe(false);
+    });
+  });
+
+  // ── Gestión de foco ───────────────────────────────────────────────────────
+  describe('gestión de foco', () => {
+    it('onNameFocus activa isNameFocused y desactiva los demás', async () => {
+      await setup();
+      component.onEmailFocus();
+      component.onNameFocus();
+      expect(component.isNameFocused()).toBe(true);
+      expect(component.isEmailFocused()).toBe(false);
+      expect(component.isPasswordFocused()).toBe(false);
+      expect(component.currentFieldType()).toBe('name');
+    });
+
+    it('onNameBlur desactiva isNameFocused y limpia currentFieldType', async () => {
+      await setup();
+      component.onNameFocus();
+      component.onNameBlur();
+      expect(component.isNameFocused()).toBe(false);
+      expect(component.currentFieldType()).toBeNull();
+    });
+
+    it('onEmailFocus activa isEmailFocused y desactiva los demás', async () => {
+      await setup();
+      component.onNameFocus();
+      component.onEmailFocus();
+      expect(component.isEmailFocused()).toBe(true);
+      expect(component.isNameFocused()).toBe(false);
+      expect(component.isPasswordFocused()).toBe(false);
+      expect(component.currentFieldType()).toBe('email');
+    });
+
+    it('onEmailBlur desactiva isEmailFocused', async () => {
+      await setup();
+      component.onEmailFocus();
+      component.onEmailBlur();
+      expect(component.isEmailFocused()).toBe(false);
+      expect(component.currentFieldType()).toBeNull();
+    });
+
+    it('onPasswordAreaFocus activa isPasswordFocused y desactiva los demás', async () => {
+      await setup();
+      component.onEmailFocus();
+      component.onPasswordAreaFocus();
+      expect(component.isPasswordFocused()).toBe(true);
+      expect(component.isEmailFocused()).toBe(false);
+      expect(component.isNameFocused()).toBe(false);
+      expect(component.currentFieldType()).toBeNull();
+    });
+
+    it('onPasswordAreaBlur desactiva isPasswordFocused si foco sale del área', async () => {
+      await setup();
+      component.onPasswordAreaFocus();
+      const fakeEvent = { relatedTarget: null, currentTarget: document.createElement('div') } as unknown as FocusEvent;
+      component.onPasswordAreaBlur(fakeEvent);
+      expect(component.isPasswordFocused()).toBe(false);
+    });
+  });
+
+  // ── resetForm ─────────────────────────────────────────────────────────────
+  describe('resetForm', () => {
+    it('limpia el formulario', async () => {
+      await setup();
+      component.registerForm.setValue({
+        name: 'Juan',
+        email: 'j@j.com',
+        password: 'Password1!',
+        confirmPassword: 'Password1!',
+      });
+      component.resetForm();
+      expect(component.registerForm.value.name).toBeFalsy();
+    });
+
+    it('restablece submitted a false', async () => {
+      await setup();
+      component.submitted.set(true);
+      component.resetForm();
+      expect(component.submitted()).toBe(false);
+    });
+
+    it('limpia el error', async () => {
+      await setup();
+      component.error.set('Algo salió mal');
+      component.resetForm();
+      expect(component.error()).toBe('');
+    });
+
+    it('desactiva todos los signals de foco', async () => {
+      await setup();
+      component.onEmailFocus();
+      component.resetForm();
+      expect(component.isEmailFocused()).toBe(false);
+      expect(component.isNameFocused()).toBe(false);
+      expect(component.isPasswordFocused()).toBe(false);
+    });
+  });
+
+  // ── onSubmit con formulario inválido ──────────────────────────────────────
+  describe('onSubmit', () => {
+    it('marca submitted en true al intentar enviar formulario inválido', async () => {
+      await setup();
+      expect(component.submitted()).toBe(false);
+      component.onSubmit();
+      await fixture.whenStable();
+      expect(component.submitted()).toBe(true);
+    });
+
+    it('no activa loading si el formulario es inválido', async () => {
+      await setup();
+      component.onSubmit();
+      await fixture.whenStable();
+      expect(component.loading()).toBe(false);
+    });
+  });
+
+  // ── togglePasswordVisibility ──────────────────────────────────────────────
+  describe('togglePasswordVisibility', () => {
+    it('cambia showPassword de false a true', async () => {
+      await setup();
+      component.togglePasswordVisibility();
+      expect(component.showPassword()).toBe(true);
+    });
+
+    it('cambia showPassword de true a false', async () => {
+      await setup();
+      component.togglePasswordVisibility();
+      component.togglePasswordVisibility();
+      expect(component.showPassword()).toBe(false);
+    });
+  });
+
+  // ── toggleConfirmPasswordVisibility ───────────────────────────────────────
+  describe('toggleConfirmPasswordVisibility', () => {
+    it('cambia showConfirmPassword de false a true', async () => {
+      await setup();
+      component.toggleConfirmPasswordVisibility();
+      expect(component.showConfirmPassword()).toBe(true);
+    });
+  });
+
+  // ── Getter f ──────────────────────────────────────────────────────────────
+  describe('getter f', () => {
+    it('retorna los controles del formulario', async () => {
+      await setup();
+      expect(component.f['name']).toBeDefined();
+      expect(component.f['email']).toBeDefined();
+      expect(component.f['password']).toBeDefined();
+    });
   });
 });

--- a/src/app/shared/animated-pet/animated-pet.component.spec.ts
+++ b/src/app/shared/animated-pet/animated-pet.component.spec.ts
@@ -15,7 +15,47 @@ describe('AnimatedPetComponent', () => {
     await fixture.whenStable();
   });
 
+  afterEach(() => TestBed.resetTestingModule());
+
+  // ── Creación ──────────────────────────────────────────────────────────────
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  // ── Estado inicial de signals ─────────────────────────────────────────────
+  describe('estado inicial', () => {
+    it('eyePositionX inicia en 0', () => {
+      expect(component.eyePositionX()).toBe(0);
+    });
+
+    it('eyePositionY inicia en 0', () => {
+      expect(component.eyePositionY()).toBe(0);
+    });
+
+    it('isBlinking inicia en false', () => {
+      expect(component.isBlinking()).toBe(false);
+    });
+  });
+
+  // ── resetEyePosition ─────────────────────────────────────────────────────
+  describe('resetEyePosition', () => {
+    it('restaura eyePositionX a 0', () => {
+      component.eyePositionX.set(10);
+      component.resetEyePosition();
+      expect(component.eyePositionX()).toBe(0);
+    });
+
+    it('restaura eyePositionY a 0', () => {
+      component.eyePositionY.set(15);
+      component.resetEyePosition();
+      expect(component.eyePositionY()).toBe(0);
+    });
+  });
+
+  // ── ngOnDestroy ───────────────────────────────────────────────────────────
+  describe('ngOnDestroy', () => {
+    it('limpia el intervalo de parpadeo sin lanzar error', () => {
+      expect(() => component.ngOnDestroy()).not.toThrow();
+    });
   });
 });


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción
Se amplía y actualiza la cobertura de pruebas unitarias en componentes clave del flujo de autenticación, detalles de dispositivos/órdenes y componentes visuales, adaptando además algunos tests al uso actual de señales e inputs reactivos.

Los cambios principales incluyen:
- incorporación de una suite más completa para `DevicesDetailComponent`,
- actualización de tests en modales de órdenes para reflejar el uso de `input()` y señales,
- ajuste de pruebas de `OrdersDetailComponent` al nuevo modelo reactivo basado en `signal()`,
- expansión importante de pruebas para `LoginComponent`,
- expansión importante de pruebas para `RegisterComponent`,
- adición de pruebas para `AnimatedPetComponent`,
- uso de `fixture.componentRef.setInput(...)` en lugar de asignación directa cuando aplica,
- actualización de aserciones para leer estado mediante señales (`signal()`).

## ¿Qué tipo de cambio es?
- [ ] Bugfix 🐞
- [ ] Feature ✨
- [x] Refactor 🔧
- [ ] Documentación 📚
- [ ] Otro

## ¿Cómo probar estos cambios?
1. Instalar dependencias y levantar el proyecto si es necesario.
2. Ejecutar la suite de pruebas unitarias.
3. Verificar específicamente que pasen los tests de:
   - `devices-detail.component.spec.ts`
   - `order-create-edit-modal.component.spec.ts`
   - `order-delete-modal.component.spec.ts`
   - `orders-detail.component.spec.ts`
   - `login.component.spec.ts`
   - `register.component.spec.ts`
   - `animated-pet.component.spec.ts`
4. Validar que la cobertura cubra correctamente los siguientes escenarios:
   - carga de detalle de dispositivo,
   - navegación hacia detalle de orden desde asignaciones,
   - refresco de datos,
   - carga y manejo de errores en detalle de orden,
   - estados iniciales reactivos en login/register,
   - cambios de foco en formularios,
   - toggle de visibilidad de contraseña,
   - reseteo de formularios,
   - funcionamiento base del componente visual `AnimatedPetComponent`.
5. Confirmar que los tests adaptados al uso de señales e inputs reactivos no fallen por accesos antiguos a propiedades directas.

## Checklist
- [x] El código compila y pasa los tests
- [ ] La documentación está actualizada (si aplica)
- [x] No hay warnings nuevos
- [x] Revisé el formato y convenciones de código

## Screenshots (si aplica)
No aplica.

## Issue relacionada
<!-- Si hay issues asociadas, referencia: closes #123 -->

## Notas para el revisor
- La mayor parte del PR está enfocada en testing.
- Se modernizaron pruebas para componentes que ahora usan `signal()` e `input()`.
- Se reemplazaron asignaciones directas de inputs por `fixture.componentRef.setInput(...)` donde corresponde.
-
