### PR TITLE
feat(issue-36): Angular 21 compliance — signals, Signal Forms, OnPush

### DIFF
--- a/src/app/layouts/private/private-layout/private-layout.component.html
+++ b/src/app/layouts/private/private-layout/private-layout.component.html
@@ -1,6 +1,6 @@
 <div class="drawer lg:drawer-open">
   <!-- Checkbox para controlar en mobile -->
-  <input id="sidebar-drawer" type="checkbox" class="drawer-toggle" [checked]="isSidebarOpen" />
+  <input id="sidebar-drawer" type="checkbox" class="drawer-toggle" [checked]="isSidebarOpen()" />
 
   <div class="drawer-content flex flex-col">
     <!-- NAVBAR -->

--- a/src/app/layouts/private/private-layout/private-layout.component.ts
+++ b/src/app/layouts/private/private-layout/private-layout.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { AuthService } from '../../../core/services/auth.service';
 import { toast } from 'ngx-sonner';
@@ -15,7 +15,7 @@ export class PrivateLayoutComponent {
   protected readonly authService = inject(AuthService);
   protected readonly themeService = inject(ThemeService);
 
-  isSidebarOpen = true;
+  readonly isSidebarOpen = signal(true);
 
   get currentTheme(): Theme { return this.themeService.currentTheme(); }
   get user() { return this.authService.currentUser(); }
@@ -37,7 +37,7 @@ export class PrivateLayoutComponent {
   }
 
   toggleSidebar(): void {
-    this.isSidebarOpen = !this.isSidebarOpen;
+    this.isSidebarOpen.update(v => !v);
   }
 
   changeTheme(theme: 'light' | 'dark' | 'infragest'): void {

--- a/src/app/modules/private/devices/modals/device-create-edit-modal/device-create-edit-modal.component.html
+++ b/src/app/modules/private/devices/modals/device-create-edit-modal/device-create-edit-modal.component.html
@@ -16,48 +16,33 @@
         </svg>
         {{ device() ? 'Editar dispositivo' : 'Nuevo dispositivo' }}
       </h3>
-      <form [formGroup]="deviceForm" (ngSubmit)="submit()" class="space-y-6">
+      <form (submit)="onSubmit(); $event.preventDefault()" class="space-y-6">
         <!-- Nombre -->
         <div>
           <label class="label text-base font-semibold text-blue-700 mb-2">Nombre</label>
           <div class="relative">
             <input
               class="input input-bordered w-full pr-12 text-lg transition-all focus:ring-2 focus:ring-blue-400 bg-white/70"
-              formControlName="name" placeholder="Nombre completo"
-              [class.input-error]="submitted() && deviceForm.get('name')?.invalid" autocomplete="off" />
-            @if (deviceForm.get('name')?.valid && deviceForm.get('name')?.touched) {
-              <svg
-                class="h-5 w-5 text-success absolute right-5 top-1/2 -translate-y-1/2" fill="none" stroke="currentColor"
-                stroke-width="2" viewBox="0 0 24 24">
+              [formField]="deviceForm.name" placeholder="Nombre completo"
+              [class.input-error]="deviceForm.name().touched() && deviceForm.name().errors().length"
+              autocomplete="off" />
+            @if (deviceForm.name().touched() && deviceForm.name().valid()) {
+              <svg class="h-5 w-5 text-success absolute right-5 top-1/2 -translate-y-1/2" fill="none"
+                stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
               </svg>
             }
-            @if (submitted() && deviceForm.get('name')?.invalid) {
-              <svg
-                class="h-5 w-5 text-error absolute right-5 top-1/2 -translate-y-1/2" fill="none" stroke="currentColor"
-                stroke-width="2" viewBox="0 0 24 24">
+            @if (deviceForm.name().touched() && deviceForm.name().errors().length) {
+              <svg class="h-5 w-5 text-error absolute right-5 top-1/2 -translate-y-1/2" fill="none"
+                stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
               </svg>
             }
           </div>
-          @if (submitted() && deviceForm.get('name')?.hasError('invalidFullName')) {
-            <div class="text-xs text-error mt-2 transition-all"
-              >¡Escribe nombre y apellido válidos!
-            </div>
-          }
-          @if (submitted() && deviceForm.get('name')?.hasError('invalidName')) {
-            <div class="text-xs text-error mt-2 transition-all"
-              >No se permiten números en el nombre.
-            </div>
-          }
-          @if (submitted() && deviceForm.get('name')?.hasError('whitespace')) {
-            <div class="text-xs text-error mt-2 transition-all"
-              >No debe contener solo espacios en
-            blanco.</div>
-          }
-          @if (submitted() && deviceForm.get('name')?.hasError('required')) {
-            <div class="text-xs text-error mt-2 transition-all"
-            >Campo obligatorio.</div>
+          @if (deviceForm.name().touched()) {
+            @for (error of deviceForm.name().errors(); track error.kind) {
+              <div class="text-xs text-error mt-2 transition-all">{{ error.message }}</div>
+            }
           }
         </div>
         <!-- Marca -->
@@ -66,31 +51,26 @@
           <div class="relative">
             <input
               class="input input-bordered w-full pr-12 text-lg transition-all focus:ring-2 focus:ring-blue-400 bg-white/70"
-              formControlName="brand" placeholder="Marca"
-              [class.input-error]="submitted() && deviceForm.get('brand')?.invalid" autocomplete="off" />
-            @if (deviceForm.get('brand')?.valid && deviceForm.get('brand')?.touched) {
-              <svg
-                class="h-5 w-5 text-success absolute right-5 top-1/2 -translate-y-1/2" fill="none" stroke="currentColor"
-                stroke-width="2" viewBox="0 0 24 24">
+              [formField]="deviceForm.brand" placeholder="Marca"
+              [class.input-error]="deviceForm.brand().touched() && deviceForm.brand().errors().length"
+              autocomplete="off" />
+            @if (deviceForm.brand().touched() && deviceForm.brand().valid()) {
+              <svg class="h-5 w-5 text-success absolute right-5 top-1/2 -translate-y-1/2" fill="none"
+                stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
               </svg>
             }
-            @if (submitted() && deviceForm.get('brand')?.invalid) {
-              <svg
-                class="h-5 w-5 text-error absolute right-5 top-1/2 -translate-y-1/2" fill="none" stroke="currentColor"
-                stroke-width="2" viewBox="0 0 24 24">
+            @if (deviceForm.brand().touched() && deviceForm.brand().errors().length) {
+              <svg class="h-5 w-5 text-error absolute right-5 top-1/2 -translate-y-1/2" fill="none"
+                stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
               </svg>
             }
           </div>
-          @if (submitted() && deviceForm.get('brand')?.hasError('required')) {
-            <div class="text-xs text-error mt-2 transition-all"
-            >Campo obligatorio.</div>
-          }
-          @if (submitted() && deviceForm.get('brand')?.hasError('whitespace')) {
-            <div class="text-xs text-error mt-2 transition-all"
-              >No debe contener solo espacios en
-            blanco.</div>
+          @if (deviceForm.brand().touched()) {
+            @for (error of deviceForm.brand().errors(); track error.kind) {
+              <div class="text-xs text-error mt-2 transition-all">{{ error.message }}</div>
+            }
           }
         </div>
         <!-- Código de barras -->
@@ -99,41 +79,32 @@
           <div class="relative">
             <input
               class="input input-bordered w-full pr-12 text-lg transition-all focus:ring-2 focus:ring-blue-400 bg-white/70"
-              formControlName="barcode" placeholder="Ej: 123456"
-              [class.input-error]="submitted() && deviceForm.get('barcode')?.invalid" autocomplete="off" />
-            @if (deviceForm.get('barcode')?.valid && deviceForm.get('barcode')?.touched) {
-              <svg
-                class="h-5 w-5 text-success absolute right-5 top-1/2 -translate-y-1/2" fill="none" stroke="currentColor"
-                stroke-width="2" viewBox="0 0 24 24">
+              [formField]="deviceForm.barcode" placeholder="Ej: 123456"
+              [class.input-error]="deviceForm.barcode().touched() && deviceForm.barcode().errors().length"
+              autocomplete="off" />
+            @if (deviceForm.barcode().touched() && deviceForm.barcode().valid()) {
+              <svg class="h-5 w-5 text-success absolute right-5 top-1/2 -translate-y-1/2" fill="none"
+                stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
               </svg>
             }
-            @if (submitted() && deviceForm.get('barcode')?.invalid) {
-              <svg
-                class="h-5 w-5 text-error absolute right-5 top-1/2 -translate-y-1/2" fill="none" stroke="currentColor"
-                stroke-width="2" viewBox="0 0 24 24">
+            @if (deviceForm.barcode().touched() && deviceForm.barcode().errors().length) {
+              <svg class="h-5 w-5 text-error absolute right-5 top-1/2 -translate-y-1/2" fill="none"
+                stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
               </svg>
             }
           </div>
-          @if (submitted() && deviceForm.get('barcode')?.hasError('required')) {
-            <div class="text-xs text-error mt-2 transition-all"
-            >Campo obligatorio.</div>
-          }
-          @if (submitted() && deviceForm.get('barcode')?.hasError('minlength')) {
-            <div class="text-xs text-error mt-2 transition-all"
-            >Mínimo 6 caracteres.</div>
-          }
-          @if (submitted() && deviceForm.get('barcode')?.hasError('whitespace')) {
-            <div class="text-xs text-error mt-2 transition-all"
-              >No debe contener solo espacios en
-            blanco.</div>
+          @if (deviceForm.barcode().touched()) {
+            @for (error of deviceForm.barcode().errors(); track error.kind) {
+              <div class="text-xs text-error mt-2 transition-all">{{ error.message }}</div>
+            }
           }
         </div>
         <!-- Estado -->
         <div>
           <label class="label text-base font-semibold text-blue-700 mb-2">Estado</label>
-          <select class="select select-bordered w-full text-lg bg-white/70" formControlName="status">
+          <select class="select select-bordered w-full text-lg bg-white/70" [formField]="deviceForm.status">
             @for (entry of deviceStatusEntries; track entry) {
               <option [value]="entry[1]">
                 {{ DeviceStatusLabels[entry[1]] }}
@@ -142,8 +113,7 @@
           </select>
         </div>
         @if (device()?.assignmentActive) {
-          <div
-            class="bg-blue-100 border border-blue-300 rounded px-3 py-2 mb-2 text-blue-800 text-sm">
+          <div class="bg-blue-100 border border-blue-300 rounded px-3 py-2 mb-2 text-blue-800 text-sm">
             <strong>Dispositivo asignado:</strong> No puedes editar el estado ni modificar datos mientras el dispositivo
             esté asignado.
           </div>
@@ -151,7 +121,7 @@
         <!-- Loader y error global -->
         @if (formLoading()) {
           <div class="flex justify-center mt-6">
-            <span class="loading loading-spinner loading-lg"></span> {{formLoading()}}
+            <span class="loading loading-spinner loading-lg"></span>
           </div>
         }
         @if (formError()) {
@@ -168,7 +138,7 @@
             Cancelar
           </button>
           @if (!device()?.assignmentActive) {
-            <button type="submit" class="btn btn-primary btn-lg shadow-lg" [disabled]="formLoading() || deviceForm.invalid">
+            <button type="submit" class="btn btn-primary btn-lg shadow-lg" [disabled]="formLoading() || deviceForm().invalid()">
               @if (formLoading()) {
                 <span class="loading loading-spinner loading-xs mr-2"></span>
               }

--- a/src/app/modules/private/devices/modals/device-create-edit-modal/device-create-edit-modal.component.ts
+++ b/src/app/modules/private/devices/modals/device-create-edit-modal/device-create-edit-modal.component.ts
@@ -1,22 +1,16 @@
 import {
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
-  DestroyRef,
-  OnInit,
-  effect,
   inject,
   input,
+  linkedSignal,
   output,
   signal,
-  untracked,
 } from '@angular/core';
-import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { finalize } from 'rxjs';
+import { FormField, disabled, form, minLength, required, submit, validate } from '@angular/forms/signals';
+import { firstValueFrom } from 'rxjs';
 import { Device, DeviceFormResult, DeviceStatus, DeviceStatusLabels } from '../../models/device.model';
 import { DevicesService } from '../../services/devices.service';
-import { noWhitespaceValidator } from '../../../../../core/utils/form-validators.utils';
 import { toast } from 'ngx-sonner';
 
 @Component({
@@ -24,21 +18,16 @@ import { toast } from 'ngx-sonner';
   templateUrl: './device-create-edit-modal.component.html',
   standalone: true,
   styleUrls: ['./device-create-edit-modal.component.css'],
-  imports: [ReactiveFormsModule],
+  imports: [FormField],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DeviceCreateEditModalComponent implements OnInit {
-  private readonly fb = inject(FormBuilder);
+export class DeviceCreateEditModalComponent {
   private readonly devicesService = inject(DevicesService);
-  private readonly cd = inject(ChangeDetectorRef);
-  private readonly destroyRef = inject(DestroyRef);
 
   readonly device = input<Device | null>(null);
   readonly close = output<void>();
   readonly save = output<DeviceFormResult>();
 
-  deviceForm!: FormGroup;
-  readonly submitted = signal(false);
   readonly formError = signal('');
   readonly formLoading = signal(false);
 
@@ -46,90 +35,74 @@ export class DeviceCreateEditModalComponent implements OnInit {
   readonly DeviceStatusLabels = DeviceStatusLabels;
   readonly deviceStatusEntries = Object.entries(DeviceStatus) as [string, DeviceStatus][];
 
-  constructor() {
-    // Re-initialize form when device input changes after first render
-    effect(() => {
-      this.device();
-      untracked(() => { if (this.deviceForm) this.initForm(); });
+  readonly deviceModel = linkedSignal({
+    source: this.device,
+    computation: (device: Device | null) => ({
+      name: device?.name ?? '',
+      brand: device?.brand ?? '',
+      barcode: device?.barcode ?? '',
+      status: device?.status ?? DeviceStatus.GOOD_CONDITION,
+    }),
+  });
+
+  readonly deviceForm = form(this.deviceModel, (s) => {
+    required(s.name, { message: 'Campo obligatorio.' });
+    validate(s.name, ({ value }) => {
+      if (!value().trim()) return { kind: 'whitespace', message: 'No debe contener solo espacios en blanco.' };
+      return undefined;
     });
-  }
+    disabled(s.name, () => !!this.device()?.assignmentActive);
 
-  ngOnInit(): void {
-    this.initForm();
-  }
-
-  private initForm(): void {
-    const device = this.device();
-    this.deviceForm = this.fb.group({
-      name: [device?.name ?? '', [Validators.required, noWhitespaceValidator()]],
-      brand: [device?.brand ?? '', [Validators.required, noWhitespaceValidator()]],
-      barcode: [device?.barcode ?? '', [Validators.required, Validators.minLength(6), noWhitespaceValidator()]],
-      status: [device?.status ?? DeviceStatus.GOOD_CONDITION, Validators.required],
+    required(s.brand, { message: 'Campo obligatorio.' });
+    validate(s.brand, ({ value }) => {
+      if (!value().trim()) return { kind: 'whitespace', message: 'No debe contener solo espacios en blanco.' };
+      return undefined;
     });
-    if (device?.assignmentActive) {
-      this.deviceForm.disable();
-    } else {
-      this.deviceForm.enable();
-    }
-    this.submitted.set(false);
-    this.formError.set('');
-    this.formLoading.set(false);
-  }
+    disabled(s.brand, () => !!this.device()?.assignmentActive);
 
-  submit(): void {
-    this.submitted.set(true);
-    this.formError.set('');
+    required(s.barcode, { message: 'Campo obligatorio.' });
+    minLength(s.barcode, 6, { message: 'Mínimo 6 caracteres.' });
+    validate(s.barcode, ({ value }) => {
+      if (!value().trim()) return { kind: 'whitespace', message: 'No debe contener solo espacios en blanco.' };
+      return undefined;
+    });
+    disabled(s.barcode, () => !!this.device()?.assignmentActive);
 
-    const device = this.device();
-    if (device && !this.hasChanges()) {
-      toast.warning('No se detectaron cambios en el dispositivo');
-      this.cd.markForCheck();
-      return;
-    }
+    required(s.status, { message: 'Campo obligatorio.' });
+    disabled(s.status, () => !!this.device()?.assignmentActive);
+  });
 
-    if (this.deviceForm.invalid) return;
+  onSubmit(): void {
+    submit(this.deviceForm, async () => {
+      const device = this.device();
+      if (device && !this.deviceForm().dirty()) {
+        toast.warning('No se detectaron cambios en el dispositivo');
+        return;
+      }
 
-    this.formLoading.set(true);
-    this.cd.markForCheck();
-    const value = this.deviceForm.value;
-    const isEdit = !!device;
-    const op$ = device
-      ? this.devicesService.updateDevice(device.id, value)
-      : this.devicesService.createDevice(value);
+      this.formLoading.set(true);
+      this.formError.set('');
+      const model = this.deviceModel();
+      const isEdit = !!device;
+      const op$ = device
+        ? this.devicesService.updateDevice(device.id, model)
+        : this.devicesService.createDevice(model);
 
-    op$
-      .pipe(
-        takeUntilDestroyed(this.destroyRef),
-        finalize(() => {
-          this.formLoading.set(false);
-          this.cd.markForCheck();
-        }),
-      )
-      .subscribe({
-        next: (saved: Device) => {
-          this.save.emit({ device: saved, mode: isEdit ? 'edit' : 'create' });
-        },
-        error: (err) => {
-          const msg = err?.error?.message || err?.message || 'Error al guardar el dispositivo';
-          this.formError.set(msg);
-          toast.error('Error al guardar el dispositivo', { description: msg });
-        },
-      });
+      try {
+        const saved = await firstValueFrom(op$);
+        this.save.emit({ device: saved, mode: isEdit ? 'edit' : 'create' });
+      } catch (err: unknown) {
+        const anyErr = err as { error?: { message?: string }; message?: string };
+        const msg = anyErr?.error?.message || anyErr?.message || 'Error al guardar el dispositivo';
+        this.formError.set(msg);
+        toast.error('Error al guardar el dispositivo', { description: msg });
+      } finally {
+        this.formLoading.set(false);
+      }
+    });
   }
 
   closeModal(): void {
     this.close.emit();
-  }
-
-  private hasChanges(): boolean {
-    const device = this.device();
-    if (!device) return true;
-    const current = this.deviceForm.value;
-    return (
-      current.name !== device.name ||
-      current.brand !== device.brand ||
-      current.barcode !== device.barcode ||
-      current.status !== device.status
-    );
   }
 }

--- a/src/app/modules/private/devices/pages/devices/devices.component.html
+++ b/src/app/modules/private/devices/pages/devices/devices.component.html
@@ -1,4 +1,4 @@
-@if (loading$ | async) {
+@if (isLoading()) {
   <div class="toast toast-top toast-center z-50">
     <div class="alert alert-info gap-2">
       <span class="loading loading-spinner loading-sm"></span>
@@ -131,7 +131,7 @@
           Limpiar
         </button>
         <!-- Botón masivo OR bloque masivo (solo uno visible según modo) -->
-        @if (!bulkMode) {
+        @if (!bulkMode()) {
           <button class="btn btn-warning" (click)="activateBulkMode()">
             <svg class="w-5 h-5 inline-block mr-2" fill="none" stroke="currentColor" stroke-width="2"
               viewBox="0 0 24 24">
@@ -140,7 +140,7 @@
             Actualizar estados masivamente
           </button>
         } @else {
-          <select [(ngModel)]="bulkStatus" class="select select-bordered w-48">
+          <select [ngModel]="bulkStatus()" (ngModelChange)="bulkStatus.set($event)" class="select select-bordered w-48">
             <option [ngValue]="null">Selecciona nuevo estado…</option>
             @for (s of [DeviceStatus.GOOD_CONDITION, DeviceStatus.FAIR, DeviceStatus.OCCUPIED, DeviceStatus.NEEDS_REPAIR]; track s) {
               <option
@@ -150,7 +150,7 @@
             }
           </select>
           <button class="btn btn-success flex items-center gap-2"
-            [disabled]="countSelectedDevices() === 0 || !bulkStatus" (click)="updateDevicesStatus()">
+            [disabled]="countSelectedDevices() === 0 || !bulkStatus()" (click)="updateDevicesStatus()">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4" />
             </svg>
@@ -170,13 +170,13 @@
           </button>
         }
         <!-- Botón actualizar -->
-        @if (!bulkMode) {
+        @if (!bulkMode()) {
           <button class="btn btn-ghost gap-2 ml-auto" (click)="refreshData()"
-            [disabled]="loading$ | async">
-            @if (loading$ | async) {
+            [disabled]="isLoading()">
+            @if (isLoading()) {
               <span class="loading loading-spinner loading-xs"></span>
             }
-            @if (!(loading$ | async)) {
+            @if (!isLoading()) {
               <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none"
                 viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -184,23 +184,23 @@
               </svg>
             }
             <span class="hidden sm:inline">
-              {{ (loading$ | async) ? 'Actualizando...' : 'Actualizar' }}
+              {{ isLoading() ? 'Actualizando...' : 'Actualizar' }}
             </span>
           </button>
         }
       </div>
       <!-- MODALES -->
-      @if (showCreateModal || showEditModal) {
-        <app-device-create-edit-modal [device]="deviceToEdit"
+      @if (showCreateModal() || showEditModal()) {
+        <app-device-create-edit-modal [device]="deviceToEdit()"
           (save)="handleModalSave($event)" (close)="closeModals()">
         </app-device-create-edit-modal>
       }
-      @if (showDeleteModal) {
-        <app-device-delete-modal [device]="deviceToDelete" (deleted)="onDeviceDeleted()"
+      @if (showDeleteModal()) {
+        <app-device-delete-modal [device]="deviceToDelete()" (deleted)="onDeviceDeleted()"
           (cancel)="cancelDelete()">
         </app-device-delete-modal>
       }
-      @if (showBulkUploadModal) {
+      @if (showBulkUploadModal()) {
         <app-device-bulk-upload-modal (uploaded)="onBulkUploadSuccess($event)"
           (close)="closeBulkUploadModal()">
         </app-device-bulk-upload-modal>
@@ -213,7 +213,7 @@
               <table class="table w-full table-zebra rounded-xl shadow-lg overflow-hidden">
                 <thead class="bg-blue-100">
                   <tr>
-                    @if (bulkMode) {
+                    @if (bulkMode()) {
                       <th>
                         <input type="checkbox" [checked]="allSelectedFiltered()" (change)="toggleSelectAllFiltered($event)">
                       </th>
@@ -266,7 +266,7 @@
                 <tbody>
                   @for (device of devices; track device.id) {
                     <tr class="hover:bg-blue-50 transition">
-                      @if (bulkMode) {
+                      @if (bulkMode()) {
                         <td>
                           <input type="checkbox" [checked]="isSelected(device.id)" (change)="toggleSelectDevice(device.id)" [disabled]="device.assignmentActive ?? false" />
                         </td>

--- a/src/app/modules/private/devices/pages/devices/devices.component.ts
+++ b/src/app/modules/private/devices/pages/devices/devices.component.ts
@@ -7,10 +7,10 @@ import {
   inject,
   signal,
 } from '@angular/core';
-import { AsyncPipe, DecimalPipe } from '@angular/common';
+import { DecimalPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { catchError, of } from 'rxjs';
 import {
   Device,
@@ -31,7 +31,6 @@ import { DevicesStore } from '../../store/devices.store';
 @Component({
   selector: 'app-devices',
   imports: [
-    AsyncPipe,
     DecimalPipe,
     FormsModule,
     DeviceCreateEditModalComponent,
@@ -49,25 +48,23 @@ export class DevicesComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
   private readonly devicesService = inject(DevicesService);
 
-  readonly loading$ = inject(LoadingService).loading$;
+  readonly isLoading = toSignal(inject(LoadingService).loading$, { initialValue: false });
 
   // Template enums
   readonly DeviceStatus = DeviceStatus;
   readonly DeviceStatusLabels = DeviceStatusLabels;
   readonly DeviceStatusColors = DeviceStatusColors;
 
-  // Modal state (ephemeral UI)
-  showCreateModal = false;
-  showEditModal = false;
-  showDeleteModal = false;
-  showBulkUploadModal = false;
-  deviceToEdit: Device | null = null;
-  deviceToDelete: Device | null = null;
-  formMode: 'create' | 'edit' = 'create';
+  readonly showCreateModal = signal(false);
+  readonly showEditModal = signal(false);
+  readonly showDeleteModal = signal(false);
+  readonly showBulkUploadModal = signal(false);
+  readonly deviceToEdit = signal<Device | null>(null);
+  readonly deviceToDelete = signal<Device | null>(null);
+  readonly formMode = signal<'create' | 'edit'>('create');
 
-  // Bulk update state
-  bulkMode = false;
-  bulkStatus: DeviceStatus | null = null;
+  readonly bulkMode = signal(false);
+  readonly bulkStatus = signal<DeviceStatus | null>(null);
 
   // Filter & pagination state
   readonly search = signal('');
@@ -183,11 +180,11 @@ export class DevicesComponent implements OnInit {
 
   updateDevicesStatus(): void {
     const selectedIds = [...this._selectedIds()];
-    if (!this.bulkStatus || selectedIds.length === 0) return;
+    if (!this.bulkStatus() || selectedIds.length === 0) return;
 
     const request: DeviceUpdateBatchRq = {
       deviceIds: selectedIds,
-      state: this.bulkStatus,
+      state: this.bulkStatus()!,
     };
 
     this.devicesService
@@ -202,8 +199,8 @@ export class DevicesComponent implements OnInit {
       .subscribe((result) => {
         if (result) {
           toast.success('Estados actualizados correctamente');
-          this.bulkStatus = null;
-          this.bulkMode = false;
+          this.bulkStatus.set(null);
+          this.bulkMode.set(false);
           this._selectedIds.set(new Set());
           this.loadDevices();
         }
@@ -211,51 +208,51 @@ export class DevicesComponent implements OnInit {
   }
 
   activateBulkMode(): void {
-    this.bulkMode = true;
+    this.bulkMode.set(true);
   }
 
   cancelBulkMode(): void {
-    this.bulkMode = false;
-    this.bulkStatus = null;
+    this.bulkMode.set(false);
+    this.bulkStatus.set(null);
     this._selectedIds.set(new Set());
   }
 
   openCreateModal(): void {
-    this.formMode = 'create';
-    this.deviceToEdit = null;
-    this.showCreateModal = true;
-    this.showEditModal = false;
+    this.formMode.set('create');
+    this.deviceToEdit.set(null);
+    this.showCreateModal.set(true);
+    this.showEditModal.set(false);
   }
 
   openEditModal(device: Device): void {
-    this.formMode = 'edit';
-    this.deviceToEdit = device;
-    this.showEditModal = true;
-    this.showCreateModal = false;
+    this.formMode.set('edit');
+    this.deviceToEdit.set(device);
+    this.showEditModal.set(true);
+    this.showCreateModal.set(false);
   }
 
   openDeleteModal(device: Device): void {
-    this.deviceToDelete = device;
-    this.showDeleteModal = true;
+    this.deviceToDelete.set(device);
+    this.showDeleteModal.set(true);
   }
 
   onDeviceDeleted(): void {
-    this.showDeleteModal = false;
-    this.deviceToDelete = null;
+    this.showDeleteModal.set(false);
+    this.deviceToDelete.set(null);
     this.loadDevices();
   }
 
   cancelDelete(): void {
-    this.showDeleteModal = false;
-    this.deviceToDelete = null;
+    this.showDeleteModal.set(false);
+    this.deviceToDelete.set(null);
   }
 
   closeModals(): void {
-    this.showCreateModal = false;
-    this.showEditModal = false;
-    this.showDeleteModal = false;
-    this.deviceToEdit = null;
-    this.deviceToDelete = null;
+    this.showCreateModal.set(false);
+    this.showEditModal.set(false);
+    this.showDeleteModal.set(false);
+    this.deviceToEdit.set(null);
+    this.deviceToDelete.set(null);
   }
 
   handleModalSave({ mode }: DeviceFormResult): void {
@@ -273,11 +270,11 @@ export class DevicesComponent implements OnInit {
   }
 
   openBulkUploadModal(): void {
-    this.showBulkUploadModal = true;
+    this.showBulkUploadModal.set(true);
   }
 
   closeBulkUploadModal(): void {
-    this.showBulkUploadModal = false;
+    this.showBulkUploadModal.set(false);
   }
 
   onBulkUploadSuccess(uploadedDevices: Device[]): void {

--- a/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.html
+++ b/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.html
@@ -16,85 +16,76 @@
         {{ order() ? 'Editar Orden' : 'Nueva Orden' }}
       </h3>
 
-      <form [formGroup]="orderForm" (ngSubmit)="onSubmit()" class="space-y-6">
+      <form (submit)="onSubmit(); $event.preventDefault()" class="space-y-6">
         <!-- Descripción -->
         <div>
           <label class="label text-base font-semibold text-blue-700 mb-2">Descripción</label>
           <div class="relative">
-            <input formControlName="description" type="text"
+            <input [formField]="orderForm.description" type="text"
               class="input input-bordered w-full pr-12 text-lg bg-white/70 focus:ring-2 focus:ring-blue-400 transition-all"
-              placeholder="Breve descripción" [class.input-error]="submitted() && orderForm.get('description')?.invalid"
+              placeholder="Breve descripción"
+              [class.input-error]="orderForm.description().touched() && orderForm.description().errors().length"
               autocomplete="off" />
-            @if (orderForm.get('description')?.valid && orderForm.get('description')?.touched) {
-              <svg
-                class="h-5 w-5 text-success absolute right-5 top-1/2 -translate-y-1/2" fill="none" stroke="currentColor"
-                stroke-width="2" viewBox="0 0 24 24">
+            @if (orderForm.description().touched() && orderForm.description().valid()) {
+              <svg class="h-5 w-5 text-success absolute right-5 top-1/2 -translate-y-1/2" fill="none"
+                stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
               </svg>
             }
-            @if (submitted() && orderForm.get('description')?.invalid) {
-              <svg
-                class="h-5 w-5 text-error absolute right-5 top-1/2 -translate-y-1/2" fill="none" stroke="currentColor"
-                stroke-width="2" viewBox="0 0 24 24">
+            @if (orderForm.description().touched() && orderForm.description().errors().length) {
+              <svg class="h-5 w-5 text-error absolute right-5 top-1/2 -translate-y-1/2" fill="none"
+                stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
               </svg>
             }
           </div>
-          @if (submitted() && orderForm.get('description')?.hasError('whitespace')) {
-            <div class="text-xs text-error mt-2 transition-all"
-              >No debe contener solo espacios
-            en blanco.</div>
-          }
-          @if (submitted() && orderForm.get('description')?.hasError('required')) {
-            <div class="text-xs text-error mt-2 transition-all"
-            >Campo obligatorio.</div>
+          @if (orderForm.description().touched()) {
+            @for (error of orderForm.description().errors(); track error.kind) {
+              <div class="text-xs text-error mt-2 transition-all">{{ error.message }}</div>
+            }
           }
         </div>
         <!-- Tipo de asignación -->
         <div>
           <label class="label text-base font-semibold text-blue-700 mb-2">Tipo de asignación</label>
-          <select formControlName="assignedType" class="select select-bordered w-full text-lg bg-white/70">
-            <option value="" disabled selected>Selecciona tipo de asignación</option>
+          <select [formField]="orderForm.assignedType" (change)="onAssignedTypeChange()"
+            class="select select-bordered w-full text-lg bg-white/70">
+            <option value="" disabled>Selecciona tipo de asignación</option>
             @for (tipo of assignedType; track tipo) {
-              <option [value]="tipo.value">
-                {{ tipo.label }}
-              </option>
+              <option [value]="tipo.value">{{ tipo.label }}</option>
             }
           </select>
-          @if (orderForm.get('assignedType')?.invalid && submitted()) {
-            <div class="text-xs text-error mt-2">Selecciona
-            el tipo de asignación.</div>
+          @if (orderForm.assignedType().touched() && orderForm.assignedType().errors().length) {
+            <div class="text-xs text-error mt-2">{{ orderForm.assignedType().errors()[0].message }}</div>
           }
         </div>
         <!-- Selector de grupos -->
-        @if (orderForm.get('assignedType')?.value === 'GROUP') {
+        @if (orderModel().assignedType === 'GROUP') {
           <div>
             <label class="label text-base font-semibold text-blue-700 mb-2">Grupo responsable</label>
-            <select formControlName="assigneeId" class="select select-bordered w-full text-lg bg-white/70">
-              <option value="" disabled selected>Selecciona grupo</option>
-              @for (group of groups; track group) {
+            <select [formField]="orderForm.assigneeId" class="select select-bordered w-full text-lg bg-white/70">
+              <option value="" disabled>Selecciona grupo</option>
+              @for (group of groups(); track group) {
                 <option [value]="group.id">{{ group.name }}</option>
               }
             </select>
-            @if (orderForm.get('assigneeId')?.invalid && submitted()) {
-              <div class="text-xs text-error mt-2">Selecciona un
-              grupo.</div>
+            @if (orderForm.assigneeId().touched() && orderForm.assigneeId().errors().length) {
+              <div class="text-xs text-error mt-2">{{ orderForm.assigneeId().errors()[0].message }}</div>
             }
           </div>
         }
         <!-- Selector de empleados -->
-        @if (orderForm.get('assignedType')?.value === 'EMPLOYEE') {
+        @if (orderModel().assignedType === 'EMPLOYEE') {
           <div>
             <label class="label text-base font-semibold text-blue-700 mb-2">Empleado responsable</label>
-            <select formControlName="assigneeId" class="select select-bordered w-full text-lg bg-white/70">
-              <option value="" disabled selected>Selecciona empleado</option>
-              @for (emp of employees; track emp) {
+            <select [formField]="orderForm.assigneeId" class="select select-bordered w-full text-lg bg-white/70">
+              <option value="" disabled>Selecciona empleado</option>
+              @for (emp of employees(); track emp) {
                 <option [value]="emp.id">{{ emp.fullName }}</option>
               }
             </select>
-            @if (orderForm.get('assigneeId')?.invalid && submitted()) {
-              <div class="text-xs text-error mt-2">Selecciona un
-              empleado.</div>
+            @if (orderForm.assigneeId().touched() && orderForm.assigneeId().errors().length) {
+              <div class="text-xs text-error mt-2">{{ orderForm.assigneeId().errors()[0].message }}</div>
             }
           </div>
         }
@@ -102,40 +93,40 @@
         <div>
           <label class="label text-base font-semibold text-blue-700 mb-2">Dispositivos a incluir</label>
           <div class="flex flex-wrap gap-2 mb-2">
-            @for (selectedId of orderForm.get('devicesIds')?.value; track selectedId) {
+            @for (selectedId of orderModel().devicesIds; track selectedId) {
               <span
                 class="badge badge-lg px-3 py-1 bg-blue-100 text-blue-700 border border-blue-300 font-medium flex items-center cursor-pointer shadow">
-                {{ deviceNameMap[selectedId] || 'Sin nombre' }}
+                {{ deviceNameMap()[selectedId] || 'Sin nombre' }}
                 <button type="button" class="ml-2 btn btn-xs btn-circle btn-outline btn-error border-none text-xs"
                   (click)="removeDevice(selectedId)" aria-label="Quitar dispositivo">
                   ✕
                 </button>
               </span>
             }
-            @if (!orderForm.get('devicesIds')?.value.length) {
-              <span
-              class="text-neutral-content opacity-50 text-sm">Nada seleccionado</span>
+            @if (!orderModel().devicesIds.length) {
+              <span class="text-neutral-content opacity-50 text-sm">Nada seleccionado</span>
             }
           </div>
           <div class="relative w-full">
             <button type="button"
               class="select select-bordered w-full text-lg bg-white/70 flex justify-between items-center cursor-pointer px-4 py-2 transition-all border-blue-300"
-              (click)="showDeviceDropdown = !showDeviceDropdown">
+              (click)="showDeviceDropdown.update(v => !v)">
               <span class="text-blue-700 font-medium">Añadir dispositivo...</span>
               <svg width="16" height="16" fill="none" class="text-blue-500">
                 <path d="M4 6l4 4 4-4" stroke="currentColor" stroke-width="2" />
               </svg>
             </button>
-            @if (showDeviceDropdown) {
+            @if (showDeviceDropdown()) {
               <div
                 class="absolute left-0 top-full mt-2 p-2 shadow bg-white/90 border border-blue-200 rounded-xl w-full z-50"
                 style="max-height:15rem;overflow-y:auto;">
-                <input [(ngModel)]="deviceSearch" [ngModelOptions]="{standalone: true}" (input)="filterDevices()"
+                <input [value]="deviceSearch()" (input)="deviceSearch.set($any($event.target).value)"
+                  (input)="deviceSearch.set($any($event.target).value)"
                   type="text"
                   class="input input-sm input-bordered w-full mb-2 bg-white/90 focus:ring-2 focus:ring-blue-400"
                   placeholder="Buscar dispositivo..." />
                 <ul>
-                  @for (dev of filteredDevices; track dev) {
+                  @for (dev of filteredDevices(); track dev) {
                     <li>
                       <a (click)="addDevice(dev.id)"
                         class="select select-bordered w-full text-lg bg-white/70 flex items-center justify-between px-4 py-2 cursor-pointer transition-all border-none hover:bg-blue-50 hover:text-blue-700 focus:bg-blue-100 rounded-lg">
@@ -144,34 +135,41 @@
                       </a>
                     </li>
                   }
-                  @if (filteredDevices.length === 0) {
-                    <li class="text-center text-neutral-content opacity-60 py-2">Sin
-                    coincidencias</li>
+                  @if (filteredDevices().length === 0) {
+                    <li class="text-center text-neutral-content opacity-60 py-2">Sin coincidencias</li>
                   }
                 </ul>
-                <!-- Cierra el menú -->
-                <button type="button" class="btn btn-sm btn-ghost w-full mt-2" (click)="showDeviceDropdown = false">
+                <button type="button" class="btn btn-sm btn-ghost w-full mt-2" (click)="showDeviceDropdown.set(false)">
                   Cerrar
                 </button>
               </div>
             }
           </div>
-          @if (orderForm.get('devicesIds')?.invalid && submitted()) {
+          @if (orderForm.devicesIds().touched() && orderForm.devicesIds().errors().length) {
             <div class="text-xs text-error mt-2">
-              Selecciona al menos un dispositivo.
+              {{ orderForm.devicesIds().errors()[0].message }}
             </div>
           }
         </div>
+        <!-- Error global -->
+        @if (formError()) {
+          <div class="text-error text-center mb-4 text-base font-semibold">{{ formError() }}</div>
+        }
         <!-- Botones -->
         <div class="modal-action flex flex-col sm:flex-row justify-center gap-3 sm:gap-4 mt-6 sm:mt-8">
-          <button type="button" class="btn btn-ghost btn-lg w-full sm:w-auto text-red-600 border-red-400" (click)="close.emit()">
+          <button type="button" class="btn btn-ghost btn-lg w-full sm:w-auto text-red-600 border-red-400"
+            (click)="close.emit()">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" viewBox="0 0 24 24" fill="none"
               stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
             Cancelar
           </button>
-          <button type="submit" class="btn btn-primary btn-lg w-full sm:w-auto shadow-lg">
+          <button type="submit" class="btn btn-primary btn-lg w-full sm:w-auto shadow-lg"
+            [disabled]="formLoading() || orderForm().invalid()">
+            @if (formLoading()) {
+              <span class="loading loading-spinner loading-xs mr-2"></span>
+            }
             <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" viewBox="0 0 24 24" fill="none"
               stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />

--- a/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.spec.ts
+++ b/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
+import { toast } from 'ngx-sonner';
 import { OrderCreateEditModalComponent } from './order-create-edit-modal.component';
 import { OrdersService } from '../../services/orders.service';
 import { DevicesService } from '../../../devices/services/devices.service';
@@ -116,33 +117,33 @@ describe('OrderCreateEditModalComponent', () => {
   describe('initForm', () => {
     it('inicia el formulario vacío en modo crear', async () => {
       await setup();
-      expect(component.orderForm.get('description')?.value).toBe('');
-      expect(component.orderForm.get('assignedType')?.value).toBe('');
-      expect(component.orderForm.get('assigneeId')?.value).toBe('');
-      expect(component.orderForm.get('devicesIds')?.value).toEqual([]);
+      expect(component.orderModel().description).toBe('');
+      expect(component.orderModel().assignedType).toBe('');
+      expect(component.orderModel().assigneeId).toBe('');
+      expect(component.orderModel().devicesIds).toEqual([]);
     });
 
     it('precarga valores de la orden en modo editar', async () => {
       await setup(mockOrder);
-      expect(component.orderForm.get('description')?.value).toBe(mockOrder.description);
-      expect(component.orderForm.get('assignedType')?.value).toBe(mockOrder.assigneeType);
-      expect(component.orderForm.get('assigneeId')?.value).toBe(mockOrder.assigneeId);
+      expect(component.orderModel().description).toBe(mockOrder.description);
+      expect(component.orderModel().assignedType).toBe(mockOrder.assigneeType);
+      expect(component.orderModel().assigneeId).toBe(mockOrder.assigneeId);
     });
 
     it('el formulario es inválido cuando los campos requeridos están vacíos', async () => {
       await setup();
-      expect(component.orderForm.invalid).toBe(true);
+      expect(component.orderForm().invalid()).toBe(true);
     });
 
     it('el formulario es válido con todos los campos requeridos', async () => {
       await setup();
-      component.orderForm.patchValue({
+      component.orderModel.set({
         description: 'Descripción válida',
         assignedType: 'EMPLOYEE',
         assigneeId: 'emp-1',
         devicesIds: ['dev-1'],
       });
-      expect(component.orderForm.valid).toBe(true);
+      expect(component.orderForm().valid()).toBe(true);
     });
   });
 
@@ -150,16 +151,14 @@ describe('OrderCreateEditModalComponent', () => {
   describe('filterDevices', () => {
     it('excluye dispositivos ya seleccionados', async () => {
       await setup();
-      component.orderForm.get('devicesIds')?.setValue(['dev-1']);
-      component.filterDevices();
-      expect(component.filteredDevices.every(d => d.id !== 'dev-1')).toBe(true);
+      component.orderModel.update(m => ({ ...m, devicesIds: ['dev-1'] }));
+      expect(component.filteredDevices().every(d => d.id !== 'dev-1')).toBe(true);
     });
 
     it('filtra por nombre cuando hay búsqueda', async () => {
       await setup();
-      component.deviceSearch = 'laptop';
-      component.filterDevices();
-      expect(component.filteredDevices.every(d =>
+      component.deviceSearch.set('laptop');
+      expect(component.filteredDevices().every(d =>
         d.name.toLowerCase().includes('laptop') ||
         (d.brand && d.brand.toLowerCase().includes('laptop'))
       )).toBe(true);
@@ -167,35 +166,34 @@ describe('OrderCreateEditModalComponent', () => {
 
     it('retorna todos los no-seleccionados sin búsqueda', async () => {
       await setup();
-      component.orderForm.get('devicesIds')?.setValue([]);
-      component.filterDevices();
-      expect(component.filteredDevices.length).toBeGreaterThanOrEqual(0);
+      component.orderModel.update(m => ({ ...m, devicesIds: [] }));
+      expect(component.filteredDevices().length).toBeGreaterThanOrEqual(0);
     });
   });
 
   // ── addDevice / removeDevice ───────────────────────────────────────────────
   describe('addDevice', () => {
-    it('agrega el ID al control devicesIds', async () => {
+    it('agrega el ID a devicesIds', async () => {
       await setup();
       component.addDevice('dev-2');
-      expect(component.orderForm.get('devicesIds')?.value).toContain('dev-2');
+      expect(component.orderModel().devicesIds).toContain('dev-2');
     });
 
     it('limpia el término de búsqueda al agregar', async () => {
       await setup();
-      component.deviceSearch = 'HP';
+      component.deviceSearch.set('HP');
       component.addDevice('dev-2');
-      expect(component.deviceSearch).toBe('');
+      expect(component.deviceSearch()).toBe('');
     });
   });
 
   describe('removeDevice', () => {
-    it('elimina el ID del control devicesIds', async () => {
+    it('elimina el ID de devicesIds', async () => {
       await setup();
-      component.orderForm.get('devicesIds')?.setValue(['dev-1', 'dev-2']);
+      component.orderModel.update(m => ({ ...m, devicesIds: ['dev-1', 'dev-2'] }));
       component.removeDevice('dev-1');
-      expect(component.orderForm.get('devicesIds')?.value).not.toContain('dev-1');
-      expect(component.orderForm.get('devicesIds')?.value).toContain('dev-2');
+      expect(component.orderModel().devicesIds).not.toContain('dev-1');
+      expect(component.orderModel().devicesIds).toContain('dev-2');
     });
   });
 
@@ -289,7 +287,7 @@ describe('OrderCreateEditModalComponent', () => {
       vi.spyOn(ordersServiceSpy, 'createOrder').mockReturnValue(of(mockOrder));
       const saveSpy = vi.spyOn(component.save, 'emit');
 
-      component.orderForm.patchValue({
+      component.orderModel.set({
         description: 'Nueva orden',
         assignedType: 'EMPLOYEE',
         assigneeId: 'emp-1',
@@ -303,8 +301,8 @@ describe('OrderCreateEditModalComponent', () => {
       );
     });
 
-    it('emite save con mode "edit" en modo editar', async () => {
-      const { providers, ordersServiceSpy } = buildProviders(mockOrder);
+    it('muestra advertencia si no hay cambios en modo editar', async () => {
+      const { providers } = buildProviders(mockOrder);
 
       await TestBed.configureTestingModule({
         imports: [OrderCreateEditModalComponent],
@@ -317,16 +315,14 @@ describe('OrderCreateEditModalComponent', () => {
       await fixture.whenStable();
       await fixture.whenStable();
 
-      vi.spyOn(ordersServiceSpy, 'updateOrder').mockReturnValue(of(mockOrder));
       const saveSpy = vi.spyOn(component.save, 'emit');
+      vi.spyOn(toast, 'warning');
 
-      component.orderForm.patchValue({ description: 'Descripción modificada' });
       component.onSubmit();
       await fixture.whenStable();
 
-      expect(saveSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ mode: 'edit' })
-      );
+      expect(toast.warning).toHaveBeenCalledWith('No se detectaron cambios en la orden');
+      expect(saveSpy).not.toHaveBeenCalled();
     });
 
     it('establece formError cuando el servicio falla', async () => {
@@ -347,7 +343,7 @@ describe('OrderCreateEditModalComponent', () => {
       );
       vi.spyOn(component.save, 'emit');
 
-      component.orderForm.patchValue({
+      component.orderModel.set({
         description: 'Orden',
         assignedType: 'EMPLOYEE',
         assigneeId: 'emp-1',
@@ -365,7 +361,7 @@ describe('OrderCreateEditModalComponent', () => {
     it('limpia assigneeId al cambiar el tipo de asignación', async () => {
       await setup(mockOrder);
       component.onAssignedTypeChange();
-      expect(component.orderForm.get('assigneeId')?.value).toBe('');
+      expect(component.orderModel().assigneeId).toBe('');
     });
   });
 
@@ -380,11 +376,6 @@ describe('OrderCreateEditModalComponent', () => {
 
   // ── Estado inicial ────────────────────────────────────────────────────────
   describe('estado inicial', () => {
-    it('submitted inicia en false', async () => {
-      await setup();
-      expect(component.submitted()).toBe(false);
-    });
-
     it('formLoading inicia en false', async () => {
       await setup();
       expect(component.formLoading()).toBe(false);

--- a/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.ts
+++ b/src/app/modules/private/orders/modals/order-create-edit-modal/order-create-edit-modal.component.ts
@@ -1,25 +1,18 @@
 import {
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
   DestroyRef,
   OnInit,
-  effect,
+  computed,
   inject,
   input,
+  linkedSignal,
   output,
   signal,
-  untracked,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import {
-  FormBuilder,
-  FormGroup,
-  FormsModule,
-  ReactiveFormsModule,
-  Validators,
-} from '@angular/forms';
-import { switchMap, of, map, finalize } from 'rxjs';
+import { switchMap, of, map, firstValueFrom } from 'rxjs';
+import { FormField, form, required, submit, validate } from '@angular/forms/signals';
 import { Device, DevicesBatchRq, DeviceStatus } from '../../../devices/models/device.model';
 import { DevicesService } from '../../../devices/services/devices.service';
 import { Employee, EmployeeStatus } from '../../../employees/models/employee.model';
@@ -34,14 +27,13 @@ import {
   OrderStateLabels,
   OrderStates,
 } from '../../models/orders.model';
-import { noWhitespaceValidator } from '../../../../../core/utils/form-validators.utils';
 import { toast } from 'ngx-sonner';
 
 @Component({
   selector: 'app-order-create-edit-modal',
   templateUrl: './order-create-edit-modal.component.html',
   styleUrls: ['./order-create-edit-modal.component.css'],
-  imports: [ReactiveFormsModule, FormsModule],
+  imports: [FormField],
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -49,8 +41,6 @@ export class OrderCreateEditModalComponent implements OnInit {
   private readonly devicesService = inject(DevicesService);
   private readonly groupsService = inject(GroupsService);
   private readonly employeesService = inject(EmployeesService);
-  private readonly fb = inject(FormBuilder);
-  private readonly cd = inject(ChangeDetectorRef);
   private readonly ordersService = inject(OrdersService);
   private readonly destroyRef = inject(DestroyRef);
 
@@ -58,43 +48,66 @@ export class OrderCreateEditModalComponent implements OnInit {
   readonly close = output<void>();
   readonly save = output<OrderFormResult>();
 
-  orderForm!: FormGroup;
-  readonly submitted = signal(false);
   readonly formLoading = signal(false);
   readonly formError = signal('');
 
   readonly OrderStates = OrderStates;
   readonly OrderStatesLabels = OrderStateLabels;
 
-  devices: Device[] = [];
-  employees: Employee[] = [];
-  groups: Group[] = [];
   readonly assignedType = [
     { label: 'Empleado', value: 'EMPLOYEE' },
     { label: 'Grupo', value: 'GROUP' },
   ];
 
-  showDeviceDropdown = false;
-  deviceSearch = '';
-  filteredDevices: Device[] = [];
-  deviceNameMap: { [id: string]: string } = {};
+  readonly devices = signal<Device[]>([]);
+  readonly employees = signal<Employee[]>([]);
+  readonly groups = signal<Group[]>([]);
+  readonly showDeviceDropdown = signal(false);
+  readonly deviceSearch = signal('');
 
-  constructor() {
-    effect(() => {
-      this.order();
-      untracked(() => {
-        if (this.orderForm) {
-          this.initForm();
-          this.loadDevices();
-          this.loadGroups();
-          this.loadEmployees();
-        }
-      });
+  readonly orderModel = linkedSignal({
+    source: this.order,
+    computation: (order: Order | null) => ({
+      description: order?.description ?? '',
+      assignedType: order?.assigneeType ?? '',
+      assigneeId: order?.assigneeId ?? '',
+      devicesIds: (order?.items.map((d) => d.deviceId) ?? []) as string[],
+    }),
+  });
+
+  readonly filteredDevices = computed(() => {
+    const selected = this.orderModel().devicesIds;
+    const search = this.deviceSearch().toLowerCase().trim();
+    return this.devices().filter(
+      (d) =>
+        !selected.includes(d.id) &&
+        (!search || d.name?.toLowerCase().includes(search) || d.brand?.toLowerCase().includes(search)),
+    );
+  });
+
+  readonly deviceNameMap = computed(() => {
+    const map: { [id: string]: string } = {};
+    for (const device of this.devices()) {
+      map[device.id] = device.name;
+    }
+    return map;
+  });
+
+  readonly orderForm = form(this.orderModel, (s) => {
+    required(s.description, { message: 'Campo obligatorio.' });
+    validate(s.description, ({ value }) => {
+      if (!value().trim()) return { kind: 'whitespace', message: 'No debe contener solo espacios en blanco.' };
+      return undefined;
     });
-  }
+    required(s.assignedType, { message: 'Selecciona el tipo de asignación.' });
+    required(s.assigneeId, { message: 'Selecciona un responsable.' });
+    validate(s.devicesIds, ({ value }) => {
+      if (!value().length) return { kind: 'required', message: 'Selecciona al menos un dispositivo.' };
+      return undefined;
+    });
+  });
 
   ngOnInit(): void {
-    this.initForm();
     this.loadDevices();
     this.loadGroups();
     this.loadEmployees();
@@ -121,16 +134,8 @@ export class OrderCreateEditModalComponent implements OnInit {
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe({
-        next: (devices) => {
-          this.devices = devices;
-          this.filterDevices();
-          this.updateDeviceNameMap();
-          this.cd.detectChanges();
-        },
-        error: () => {
-          this.devices = [];
-          this.cd.detectChanges();
-        },
+        next: (devices) => this.devices.set(devices),
+        error: () => this.devices.set([]),
       });
   }
 
@@ -142,8 +147,8 @@ export class OrderCreateEditModalComponent implements OnInit {
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe({
-        next: (groups) => { this.groups = groups; this.cd.detectChanges(); },
-        error: () => { this.groups = []; this.cd.detectChanges(); },
+        next: (groups) => this.groups.set(groups),
+        error: () => this.groups.set([]),
       });
   }
 
@@ -152,106 +157,59 @@ export class OrderCreateEditModalComponent implements OnInit {
       .getAllEmployees()
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: (employees) => { this.employees = employees; this.cd.detectChanges(); },
-        error: () => { this.employees = []; this.cd.detectChanges(); },
+        next: (employees) => this.employees.set(employees),
+        error: () => this.employees.set([]),
       });
-  }
-
-  filterDevices(): void {
-    const selected = this.orderForm?.get('devicesIds')?.value || [];
-    const search = (this.deviceSearch || '').toLowerCase().trim();
-    this.filteredDevices = this.devices.filter(
-      (d) =>
-        !selected.includes(d.id) &&
-        (!search || d.name?.toLowerCase().includes(search) || d.brand?.toLowerCase().includes(search)),
-    );
   }
 
   addDevice(deviceId: string): void {
-    const selected = this.orderForm.get('devicesIds')?.value || [];
-    this.orderForm.get('devicesIds')?.setValue([...selected, deviceId]);
-    this.deviceSearch = '';
-    this.filterDevices();
+    this.orderModel.update((m) => ({ ...m, devicesIds: [...m.devicesIds, deviceId] }));
+    this.deviceSearch.set('');
+    this.showDeviceDropdown.set(false);
   }
 
   removeDevice(deviceId: string): void {
-    const selected = this.orderForm.controls['devicesIds'].value || [];
-    this.orderForm.controls['devicesIds'].setValue(selected.filter((id: string) => id !== deviceId));
-    this.filterDevices();
-  }
-
-  private initForm(): void {
-    const order = this.order();
-    this.orderForm = this.fb.group({
-      description: [order?.description ?? '', [Validators.required, noWhitespaceValidator()]],
-      assignedType: [order?.assigneeType ?? '', [Validators.required]],
-      assigneeId: [order?.assigneeId ?? '', [Validators.required]],
-      devicesIds: [order?.items.map((d) => d.deviceId) ?? [], [Validators.required]],
-    });
-    this.filterDevices();
-    this.orderForm.get('assignedType')?.valueChanges.subscribe(() => {
-      this.orderForm.patchValue({ assigneeId: '' });
-    });
-    this.orderForm.get('devicesIds')?.valueChanges.subscribe(() => {
-      this.filterDevices();
-    });
-  }
-
-  onSubmit(): void {
-    this.submitted.set(true);
-    this.formError.set('');
-
-    const order = this.order();
-    if (order?.id && !this.hasChanges()) {
-      toast.warning('No se detectaron cambios en la orden');
-      this.cd.markForCheck();
-      return;
-    }
-    if (this.orderForm.invalid) return;
-
-    this.formLoading.set(true);
-    this.cd.markForCheck();
-    const formValue = this.orderForm.value;
-    const isEdit = !!order;
-    const result: CreateOrderRequest = {
-      description: formValue.description.trim(),
-      assigneeType: formValue.assignedType,
-      assigneeId: formValue.assigneeId,
-      devicesIds: formValue.devicesIds,
-    };
-    const op$ = order
-      ? this.ordersService.updateOrder(order.id, result)
-      : this.ordersService.createOrder(result);
-
-    op$
-      .pipe(
-        takeUntilDestroyed(this.destroyRef),
-        finalize(() => {
-          this.formLoading.set(false);
-          this.cd.markForCheck();
-        }),
-      )
-      .subscribe({
-        next: (savedOrder: Order) => {
-          this.save.emit({ order: savedOrder, mode: isEdit ? 'edit' : 'create' });
-        },
-        error: (err) => {
-          const msg = err?.error?.message || err?.message || 'Error al guardar la orden';
-          this.formError.set(msg);
-          toast.error('Error al guardar la orden', { description: msg });
-        },
-      });
+    this.orderModel.update((m) => ({ ...m, devicesIds: m.devicesIds.filter((id) => id !== deviceId) }));
   }
 
   onAssignedTypeChange(): void {
-    this.orderForm.patchValue({ assigneeId: '' });
+    this.orderModel.update((m) => ({ ...m, assigneeId: '' }));
   }
 
-  onSeleccionarDispositivo(deviceId: string): void {
-    const selected = this.orderForm.get('devicesIds')?.value || [];
-    this.orderForm.get('devicesIds')?.setValue([...selected, deviceId]);
-    this.deviceSearch = '';
-    this.filterDevices();
+  onSubmit(): void {
+    submit(this.orderForm, async () => {
+      const order = this.order();
+      if (order?.id && !this.orderForm().dirty()) {
+        toast.warning('No se detectaron cambios en la orden');
+        return;
+      }
+
+      this.formLoading.set(true);
+      this.formError.set('');
+      const model = this.orderModel();
+      const isEdit = !!order;
+      const result: CreateOrderRequest = {
+        description: model.description.trim(),
+        assigneeType: model.assignedType,
+        assigneeId: model.assigneeId,
+        devicesIds: model.devicesIds,
+      };
+      const op$ = order
+        ? this.ordersService.updateOrder(order.id, result)
+        : this.ordersService.createOrder(result);
+
+      try {
+        const savedOrder = await firstValueFrom(op$);
+        this.save.emit({ order: savedOrder, mode: isEdit ? 'edit' : 'create' });
+      } catch (err: unknown) {
+        const anyErr = err as { error?: { message?: string }; message?: string };
+        const msg = anyErr?.error?.message || anyErr?.message || 'Error al guardar la orden';
+        this.formError.set(msg);
+        toast.error('Error al guardar la orden', { description: msg });
+      } finally {
+        this.formLoading.set(false);
+      }
+    });
   }
 
   validateDevices(devices: Device[]): Device[] {
@@ -267,27 +225,5 @@ export class OrderCreateEditModalComponent implements OnInit {
     return groups.filter(
       (g) => Array.isArray(g.employees) && g.employees.some((e) => e.status === EmployeeStatus.ACTIVE),
     );
-  }
-
-  private hasChanges(): boolean {
-    const order = this.order();
-    if (!order) return true;
-    const current = this.orderForm.value;
-    const originalIds = order.items.map((d) => d.deviceId).sort();
-    const currentIds = [...(current.devicesIds ?? [])].sort();
-    return (
-      current.description?.trim() !== order.description ||
-      current.assignedType !== order.assigneeType ||
-      current.assigneeId !== order.assigneeId ||
-      originalIds.length !== currentIds.length ||
-      !originalIds.every((id, i) => id === currentIds[i])
-    );
-  }
-
-  private updateDeviceNameMap(): void {
-    this.deviceNameMap = {};
-    for (const device of this.devices) {
-      this.deviceNameMap[device.id] = device.name;
-    }
   }
 }

--- a/src/app/modules/private/orders/pages/orders/orders.component.html
+++ b/src/app/modules/private/orders/pages/orders/orders.component.html
@@ -26,7 +26,7 @@
           Gestión y seguimiento de órdenes en el sistema
         </div>
       </div>
-      <button class="btn btn-primary btn-lg gap-3 shadow-lg w-full md:w-auto" (click)="showCreateModal = true"
+      <button class="btn btn-primary btn-lg gap-3 shadow-lg w-full md:w-auto" (click)="showCreateModal.set(true)"
         [disabled]="!buttonsIsAvailable">
         <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
@@ -131,13 +131,13 @@
     </div>
 
     <!-- MODALES -->
-    @if (showCreateModal || showEditModal) {
-      <app-order-create-edit-modal [order]="orderToEdit"
+    @if (showCreateModal() || showEditModal()) {
+      <app-order-create-edit-modal [order]="orderToEdit()"
         (save)="handleModalSave($event)" (close)="closeModals()">
       </app-order-create-edit-modal>
     }
-    @if (showDeleteModal) {
-      <app-order-delete-modal [order]="orderToDelete" (deleted)="onOrderDeleted()"
+    @if (showDeleteModal()) {
+      <app-order-delete-modal [order]="orderToDelete()" (deleted)="onOrderDeleted()"
         (cancel)="cancelDelete()"></app-order-delete-modal>
     }
 
@@ -298,7 +298,7 @@
                   </button>
                   <button
                     class="btn btn-sm min-w-10 min-h-10 border-2 border-yellow-400 bg-white text-yellow-600 flex items-center justify-center hover:bg-yellow-100 hover:border-yellow-500 hover:text-yellow-700 transition-all duration-150"
-                    (click)="orderToEdit = order; showEditModal = true;"
+                    (click)="orderToEdit.set(order); showEditModal.set(true);"
                     [attr.aria-label]="'Editar orden'" [attr.title]="'Editar orden'" type="button">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round"
@@ -307,7 +307,7 @@
                   </button>
                   <button
                     class="btn btn-sm min-w-10 min-h-10 border-2 border-red-400 bg-white text-red-600 flex items-center justify-center hover:bg-red-100 hover:border-red-500 hover:text-red-700 transition-all duration-150"
-                    (click)="orderToDelete = order; showDeleteModal = true;"
+                    (click)="orderToDelete.set(order); showDeleteModal.set(true);"
                     [attr.aria-label]="'Eliminar orden'" [attr.title]="'Eliminar orden'" type="button">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round"

--- a/src/app/modules/private/orders/pages/orders/orders.component.spec.ts
+++ b/src/app/modules/private/orders/pages/orders/orders.component.spec.ts
@@ -190,17 +190,17 @@ describe('OrdersComponent', () => {
   describe('closeModals', () => {
     it('resetea todos los estados de modal y referencias de orden', async () => {
       await setup();
-      component.showCreateModal = true;
-      component.showEditModal = true;
-      component.showDeleteModal = true;
-      component.orderToEdit = mockOrder;
-      component.orderToDelete = mockOrder;
+      component.showCreateModal.set(true);
+      component.showEditModal.set(true);
+      component.showDeleteModal.set(true);
+      component.orderToEdit.set(mockOrder);
+      component.orderToDelete.set(mockOrder);
       component.closeModals();
-      expect(component.showCreateModal).toBe(false);
-      expect(component.showEditModal).toBe(false);
-      expect(component.showDeleteModal).toBe(false);
-      expect(component.orderToEdit).toBeNull();
-      expect(component.orderToDelete).toBeNull();
+      expect(component.showCreateModal()).toBe(false);
+      expect(component.showEditModal()).toBe(false);
+      expect(component.showDeleteModal()).toBe(false);
+      expect(component.orderToEdit()).toBeNull();
+      expect(component.orderToDelete()).toBeNull();
     });
   });
 
@@ -230,11 +230,11 @@ describe('OrdersComponent', () => {
     it('resetea el estado de eliminación y recarga', async () => {
       await setup();
       const loadSpy = vi.spyOn(component, 'loadOrders');
-      component.showDeleteModal = true;
-      component.orderToDelete = mockOrder;
+      component.showDeleteModal.set(true);
+      component.orderToDelete.set(mockOrder);
       component.onOrderDeleted();
-      expect(component.showDeleteModal).toBe(false);
-      expect(component.orderToDelete).toBeNull();
+      expect(component.showDeleteModal()).toBe(false);
+      expect(component.orderToDelete()).toBeNull();
       expect(loadSpy).toHaveBeenCalled();
     });
   });
@@ -243,11 +243,11 @@ describe('OrdersComponent', () => {
     it('cierra el modal sin recargar órdenes', async () => {
       await setup();
       const loadSpy = vi.spyOn(component, 'loadOrders');
-      component.showDeleteModal = true;
-      component.orderToDelete = mockOrder;
+      component.showDeleteModal.set(true);
+      component.orderToDelete.set(mockOrder);
       component.cancelDelete();
-      expect(component.showDeleteModal).toBe(false);
-      expect(component.orderToDelete).toBeNull();
+      expect(component.showDeleteModal()).toBe(false);
+      expect(component.orderToDelete()).toBeNull();
       expect(loadSpy).not.toHaveBeenCalled();
     });
   });

--- a/src/app/modules/private/orders/pages/orders/orders.component.ts
+++ b/src/app/modules/private/orders/pages/orders/orders.component.ts
@@ -36,12 +36,11 @@ export class OrdersComponent implements OnInit {
   readonly OrderStateLabels = OrderStateLabels;
   readonly OrderStatusColors = OrderStatusColors;
 
-  // Modal state (ephemeral UI — plain properties are fine)
-  showCreateModal = false;
-  showEditModal = false;
-  showDeleteModal = false;
-  orderToEdit: Order | null = null;
-  orderToDelete: Order | null = null;
+  readonly showCreateModal = signal(false);
+  readonly showEditModal = signal(false);
+  readonly showDeleteModal = signal(false);
+  readonly orderToEdit = signal<Order | null>(null);
+  readonly orderToDelete = signal<Order | null>(null);
 
   // Signals para filtros y paginación
   private readonly _search = signal('');
@@ -116,11 +115,11 @@ export class OrdersComponent implements OnInit {
   }
 
   closeModals(): void {
-    this.showCreateModal = false;
-    this.showEditModal = false;
-    this.showDeleteModal = false;
-    this.orderToEdit = null;
-    this.orderToDelete = null;
+    this.showCreateModal.set(false);
+    this.showEditModal.set(false);
+    this.showDeleteModal.set(false);
+    this.orderToEdit.set(null);
+    this.orderToDelete.set(null);
   }
 
   handleModalSave({ mode }: OrderFormResult): void {
@@ -134,14 +133,14 @@ export class OrdersComponent implements OnInit {
   }
 
   onOrderDeleted(): void {
-    this.showDeleteModal = false;
-    this.orderToDelete = null;
+    this.showDeleteModal.set(false);
+    this.orderToDelete.set(null);
     this.loadOrders();
   }
 
   cancelDelete(): void {
-    this.showDeleteModal = false;
-    this.orderToDelete = null;
+    this.showDeleteModal.set(false);
+    this.orderToDelete.set(null);
   }
 
   goToAssignee(order: Order): void {

--- a/src/app/modules/public/auth/register/register.component.html
+++ b/src/app/modules/public/auth/register/register.component.html
@@ -5,7 +5,7 @@
     <app-animated-pet
       [isPasswordFocused]="isPasswordFocused()"
       [isTextFieldFocused]="isNameFocused() || isEmailFocused()"
-      [textFieldValue]="isNameFocused() ? f['name'].value : f['email'].value"
+      [textFieldValue]="isNameFocused() ? registerModel().name : registerModel().email"
       [focusedFieldType]="currentFieldType()">
     </app-animated-pet>
 
@@ -20,7 +20,7 @@
     </div>
 
     <!-- Register Form -->
-    <form [formGroup]="registerForm" (ngSubmit)="onSubmit()">
+    <form (submit)="onSubmit(); $event.preventDefault()">
 
       <!-- Name Field -->
       <div class="form-control">
@@ -28,31 +28,26 @@
           <span class="label-text font-semibold">Nombre Completo</span>
         </label>
         <label class="input input-bordered flex items-center gap-2"
-          [class.input-error]="submitted() && f['name'].errors">
+          [class.input-error]="registerForm.name().touched() && registerForm.name().errors().length">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="w-4 h-4 opacity-70">
             <path d="M8 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6ZM12.735 14c.618 0 1.093-.561.872-1.139a6.002 6.002 0 0 0-11.215 0c-.22.578.254 1.139.872 1.139h9.47Z" />
           </svg>
           <input
+            #nameInput
             type="text"
-            formControlName="name"
+            [formField]="registerForm.name"
             class="grow"
             placeholder="Juan Pérez García"
-            [class.input-error]="submitted() && f['name'].errors"
+            [class.input-error]="registerForm.name().touched() && registerForm.name().errors().length"
             autocomplete="name"
             (focus)="onNameFocus()"
             (blur)="onNameBlur()" />
         </label>
-        @if (submitted() && f['name'].errors) {
+        @if (registerForm.name().touched() && registerForm.name().errors().length) {
           <label class="label">
             <span class="label-text-alt text-error">
-              @if (f['name'].errors['required']) {
-                <span>El nombre es requerido</span>
-              }
-              @if (f['name'].errors['minlength']) {
-                <span>Mínimo 3 caracteres</span>
-              }
-              @if (f['name'].errors['invalidFullName']) {
-                <span>Ingresa tu nombre completo (nombre y apellido)</span>
+              @for (error of registerForm.name().errors(); track error.kind) {
+                <span>{{ error.message }}</span>
               }
             </span>
           </label>
@@ -65,7 +60,7 @@
           <span class="label-text font-semibold">Correo Electrónico</span>
         </label>
         <label class="input input-bordered flex items-center gap-2"
-          [class.input-error]="submitted() && f['email'].errors">
+          [class.input-error]="registerForm.email().touched() && registerForm.email().errors().length">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="w-4 h-4 opacity-70">
             <path
               d="M2.5 3A1.5 1.5 0 0 0 1 4.5v.793c.026.009.051.02.076.032L7.674 8.51c.206.1.446.1.652 0l6.598-3.185A.755.755 0 0 1 15 5.293V4.5A1.5 1.5 0 0 0 13.5 3h-11Z" />
@@ -74,22 +69,19 @@
           </svg>
           <input
             type="email"
-            formControlName="email"
+            [formField]="registerForm.email"
             class="grow"
             placeholder="correo@ejemplo.com"
-            [class.input-error]="submitted() && f['email'].errors"
+            [class.input-error]="registerForm.email().touched() && registerForm.email().errors().length"
             autocomplete="email"
             (focus)="onEmailFocus()"
             (blur)="onEmailBlur()" />
         </label>
-        @if (submitted() && f['email'].errors) {
+        @if (registerForm.email().touched() && registerForm.email().errors().length) {
           <label class="label">
             <span class="label-text-alt text-error">
-              @if (f['email'].errors['required']) {
-                <span>El correo es requerido</span>
-              }
-              @if (f['email'].errors['email']) {
-                <span>Ingresa un correo válido</span>
+              @for (error of registerForm.email().errors(); track error.kind) {
+                <span>{{ error.message }}</span>
               }
             </span>
           </label>
@@ -103,7 +95,7 @@
         </label>
         <label
           class="input input-bordered flex items-center gap-2"
-          [class.input-error]="submitted() && f['password'].errors"
+          [class.input-error]="registerForm.password().touched() && registerForm.password().errors().length"
           (focusin)="onPasswordAreaFocus()"
           (focusout)="onPasswordAreaBlur($event)">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="w-4 h-4 opacity-70">
@@ -114,10 +106,10 @@
           <input
             #passwordInput
             [type]="showPassword() ? 'text' : 'password'"
-            formControlName="password"
+            [formField]="registerForm.password"
             class="grow"
             placeholder="••••••••"
-            [class.input-error]="submitted() && f['password'].errors"
+            [class.input-error]="registerForm.password().touched() && registerForm.password().errors().length"
             autocomplete="new-password" />
           <button
             type="button"
@@ -143,23 +135,16 @@
             }
           </button>
         </label>
-        @if (submitted() && f['password'].errors) {
+        @if (registerForm.password().touched() && registerForm.password().errors().length) {
           <label class="label">
             <span class="label-text-alt text-error">
-              @if (f['password'].errors['required']) {
-                <span>La contraseña es requerida</span>
-              }
-              @if (f['password'].errors['minlength']) {
-                <span>Mínimo 8 caracteres</span>
-              }
-              @if (f['password'].errors['weakPassword']) {
-                <span>Debe tener mayúsculas, minúsculas y números</span>
+              @for (error of registerForm.password().errors(); track error.kind) {
+                <span>{{ error.message }}</span>
               }
             </span>
           </label>
         }
-        <!-- Password strength indicator -->
-        @if (f['password'].value && !f['password'].errors) {
+        @if (registerForm.password().value() && registerForm.password().valid()) {
           <label class="label">
             <span class="label-text-alt text-success flex items-center gap-1">
               <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -178,8 +163,8 @@
         </label>
         <label
           class="input input-bordered flex items-center gap-2"
-          [class.input-error]="submitted() && (f['confirmPassword'].errors || registerForm.errors?.['passwordMismatch'])"
-          [class.input-success]="f['confirmPassword'].value && !f['confirmPassword'].errors && !registerForm.errors?.['passwordMismatch']"
+          [class.input-error]="registerForm.confirmPassword().touched() && registerForm.confirmPassword().errors().length"
+          [class.input-success]="registerForm.confirmPassword().value() && registerForm.confirmPassword().valid()"
           (focusin)="onPasswordAreaFocus()"
           (focusout)="onPasswordAreaBlur($event)">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="w-4 h-4 opacity-70">
@@ -190,10 +175,10 @@
           <input
             #confirmPasswordInput
             [type]="showConfirmPassword() ? 'text' : 'password'"
-            formControlName="confirmPassword"
+            [formField]="registerForm.confirmPassword"
             class="grow"
             placeholder="••••••••"
-            [class.input-error]="submitted() && (f['confirmPassword'].errors || registerForm.errors?.['passwordMismatch'])"
+            [class.input-error]="registerForm.confirmPassword().touched() && registerForm.confirmPassword().errors().length"
             autocomplete="new-password" />
           <button
             type="button"
@@ -219,20 +204,16 @@
             }
           </button>
         </label>
-        @if (submitted() && (f['confirmPassword'].errors || registerForm.errors?.['passwordMismatch'])) {
+        @if (registerForm.confirmPassword().touched() && registerForm.confirmPassword().errors().length) {
           <label class="label">
             <span class="label-text-alt text-error">
-              @if (f['confirmPassword'].errors?.['required']) {
-                <span>Confirma tu contraseña</span>
-              }
-              @if (registerForm.errors?.['passwordMismatch'] && !f['confirmPassword'].errors?.['required']) {
-                <span>Las contraseñas no coinciden</span>
+              @for (error of registerForm.confirmPassword().errors(); track error.kind) {
+                <span>{{ error.message }}</span>
               }
             </span>
           </label>
         }
-        <!-- Match indicator -->
-        @if (f['confirmPassword'].value && !registerForm.errors?.['passwordMismatch'] && f['password'].value === f['confirmPassword'].value) {
+        @if (registerForm.confirmPassword().value() && registerForm.confirmPassword().valid()) {
           <label class="label">
             <span class="label-text-alt text-success flex items-center gap-1">
               <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -264,7 +245,7 @@
       </div>
 
       <!-- Reset Button -->
-      @if (submitted() && registerForm.dirty) {
+      @if (submitted() && registerForm().dirty()) {
         <div class="form-control mt-2">
           <button type="button" (click)="resetForm()" class="btn btn-ghost btn-sm">
             Limpiar formulario

--- a/src/app/modules/public/auth/register/register.component.spec.ts
+++ b/src/app/modules/public/auth/register/register.component.spec.ts
@@ -31,7 +31,6 @@ describe('RegisterComponent', () => {
 
     fixture = TestBed.createComponent(RegisterComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
     await fixture.whenStable();
   }
 
@@ -47,37 +46,37 @@ describe('RegisterComponent', () => {
   describe('initForm', () => {
     it('crea el formulario con los controles requeridos', async () => {
       await setup();
-      expect(component.registerForm.contains('name')).toBe(true);
-      expect(component.registerForm.contains('email')).toBe(true);
-      expect(component.registerForm.contains('password')).toBe(true);
-      expect(component.registerForm.contains('confirmPassword')).toBe(true);
+      expect(component.registerForm.name).toBeDefined();
+      expect(component.registerForm.email).toBeDefined();
+      expect(component.registerForm.password).toBeDefined();
+      expect(component.registerForm.confirmPassword).toBeDefined();
     });
 
     it('formulario es inválido cuando está vacío', async () => {
       await setup();
-      expect(component.registerForm.invalid).toBe(true);
+      expect(component.registerForm().invalid()).toBe(true);
     });
 
     it('formulario es válido con datos correctos', async () => {
       await setup();
-      component.registerForm.setValue({
+      component.registerModel.set({
         name: 'Juan Pérez',
         email: 'juan@test.com',
         password: 'Password1!',
         confirmPassword: 'Password1!',
       });
-      expect(component.registerForm.valid).toBe(true);
+      expect(component.registerForm().valid()).toBe(true);
     });
 
     it('invalida si las contraseñas no coinciden', async () => {
       await setup();
-      component.registerForm.setValue({
+      component.registerModel.set({
         name: 'Juan Pérez',
         email: 'juan@test.com',
         password: 'Password1!',
         confirmPassword: 'OtraPassword1!',
       });
-      expect(component.registerForm.invalid).toBe(true);
+      expect(component.registerForm().invalid()).toBe(true);
     });
   });
 
@@ -185,14 +184,14 @@ describe('RegisterComponent', () => {
   describe('resetForm', () => {
     it('limpia el formulario', async () => {
       await setup();
-      component.registerForm.setValue({
+      component.registerModel.set({
         name: 'Juan',
         email: 'j@j.com',
         password: 'Password1!',
         confirmPassword: 'Password1!',
       });
       component.resetForm();
-      expect(component.registerForm.value.name).toBeFalsy();
+      expect(component.registerModel().name).toBeFalsy();
     });
 
     it('restablece submitted a false', async () => {

--- a/src/app/modules/public/auth/register/register.component.ts
+++ b/src/app/modules/public/auth/register/register.component.ts
@@ -2,7 +2,6 @@ import { RegisterRequest } from './../models/auth.model';
 import {
   ChangeDetectionStrategy,
   Component,
-  DestroyRef,
   ElementRef,
   OnInit,
   ViewChild,
@@ -10,47 +9,24 @@ import {
   signal,
 } from '@angular/core';
 import { AnimatedPetComponent } from '../../../../shared/animated-pet/animated-pet.component';
-import {
-  ReactiveFormsModule,
-  FormBuilder,
-  FormGroup,
-  Validators,
-} from '@angular/forms';
+import { FormField, email, form, minLength, required, submit, validate } from '@angular/forms/signals';
 import { RouterLink, Router, ActivatedRoute } from '@angular/router';
 import { toast } from 'ngx-sonner';
 import { AuthService } from '../../../../core/services/auth.service';
-import {
-  passwordMatchValidator,
-  strongPasswordValidator,
-  fullNameValidator,
-} from '../../../../core/utils/form-validators.utils';
-import {
-  Subject,
-  finalize,
-  catchError,
-  of,
-  tap,
-  switchMap,
-  filter,
-  Observable,
-} from 'rxjs';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { AuthResponse } from '../models/auth.model';
+import { firstValueFrom } from 'rxjs';
 import { sanitizeReturnUrl } from '../../../../core/utils/url.utils';
 
 @Component({
   selector: 'app-register',
-  imports: [ReactiveFormsModule, RouterLink, AnimatedPetComponent],
+  imports: [FormField, RouterLink, AnimatedPetComponent],
   templateUrl: './register.component.html',
   styleUrl: './register.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RegisterComponent implements OnInit {
-  private readonly formBuilder = inject(FormBuilder);
   private readonly authService = inject(AuthService);
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
-  private readonly destroyRef = inject(DestroyRef);
 
   @ViewChild(AnimatedPetComponent) mascot!: AnimatedPetComponent;
   @ViewChild('passwordInput') passwordInput!: ElementRef<HTMLInputElement>;
@@ -64,8 +40,6 @@ export class RegisterComponent implements OnInit {
   private isTogglingPassword = false;
   private isTogglingConfirmPassword = false;
 
-  registerForm!: FormGroup;
-
   readonly loading = signal(false);
   readonly submitted = signal(false);
   readonly error = signal('');
@@ -74,56 +48,63 @@ export class RegisterComponent implements OnInit {
 
   returnUrl = '/app/dashboard';
 
-  private readonly registerSubject$ = new Subject<void>();
+  readonly registerModel = signal({
+    name: '',
+    email: '',
+    password: '',
+    confirmPassword: '',
+  });
+
+  readonly registerForm = form(this.registerModel, (s) => {
+    required(s.name, { message: 'El nombre es requerido' });
+    minLength(s.name, 3, { message: 'Mínimo 3 caracteres' });
+    validate(s.name, ({ value }) => {
+      const v = value().trim();
+      if (!v) return undefined;
+      const words = v.split(/\s+/).filter((w: string) => w.length > 0);
+      if (words.length < 2 || !words.every((w: string) => w.length >= 2)) {
+        return { kind: 'invalidFullName', message: 'Ingresa tu nombre completo (nombre y apellido)' };
+      }
+      return undefined;
+    });
+
+    required(s.email, { message: 'El correo es requerido' });
+    email(s.email, { message: 'Ingresa un correo válido' });
+
+    required(s.password, { message: 'La contraseña es requerida' });
+    minLength(s.password, 8, { message: 'Mínimo 8 caracteres' });
+    validate(s.password, ({ value }) => {
+      const v = value();
+      if (!v) return undefined;
+      if (!/[A-Z]/.test(v) || !/[a-z]/.test(v) || !/[0-9]/.test(v)) {
+        return { kind: 'weakPassword', message: 'Debe tener mayúsculas, minúsculas y números' };
+      }
+      return undefined;
+    });
+
+    required(s.confirmPassword, { message: 'Confirma tu contraseña' });
+    validate(s.confirmPassword, ({ value, valueOf }) => {
+      const v = value();
+      if (!v) return undefined;
+      if (v !== valueOf(s.password)) {
+        return { kind: 'passwordMismatch', message: 'Las contraseñas no coinciden' };
+      }
+      return undefined;
+    });
+  });
+
+  get f() {
+    return {
+      name: this.registerForm.name,
+      email: this.registerForm.email,
+      password: this.registerForm.password,
+      confirmPassword: this.registerForm.confirmPassword,
+    };
+  }
 
   ngOnInit(): void {
-    this.initForm();
     this.getReturnUrl();
     this.checkAuthenticationStatus();
-    this.setupRegisterStream();
-  }
-
-  initForm(): void {
-    this.registerForm = this.formBuilder.group(
-      {
-        name: ['', [Validators.required, Validators.minLength(3), fullNameValidator()]],
-        email: ['', [Validators.required, Validators.email]],
-        password: ['', [Validators.required, Validators.minLength(8), strongPasswordValidator()]],
-        confirmPassword: ['', Validators.required],
-      },
-      { validators: passwordMatchValidator('password', 'confirmPassword') },
-    );
-  }
-
-  private setupRegisterStream(): void {
-    this.registerSubject$
-      .pipe(
-        filter(() => this.validateForm()),
-        tap(() => this.loading.set(true)),
-        switchMap(() => this.performRegister()),
-        filter((response) => response !== null),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe({
-        next: () => this.handleRegisterSuccess(),
-        error: (err) => {
-          this.handleRegisterError(err);
-          this.loading.set(false);
-        },
-      });
-  }
-
-  private validateForm(): boolean {
-    this.submitted.set(true);
-    this.error.set('');
-    if (this.registerForm.invalid) {
-      toast.error('Formulario inválido', {
-        description: 'Por favor completa todos los campos correctamente',
-        duration: 3000,
-      });
-      return false;
-    }
-    return true;
   }
 
   private getReturnUrl(): void {
@@ -136,34 +117,38 @@ export class RegisterComponent implements OnInit {
     }
   }
 
-  private handleRegisterSuccess(): void {
-    toast.success('¡Cuenta creada!', {
-      description: 'Redirigiendo al dashboard...',
-      duration: 2000,
-    });
-    setTimeout(() => {
-      this.router.navigate([this.returnUrl]);
-    }, 1000);
-  }
-
-  get f() {
-    return this.registerForm.controls;
-  }
-
   onSubmit(): void {
-    this.registerSubject$.next();
+    this.submitted.set(true);
+    this.error.set('');
+    submit(this.registerForm, async () => {
+      this.loading.set(true);
+      const model = this.registerModel();
+      const registerData: RegisterRequest = {
+        name: model.name,
+        email: model.email,
+        password: model.password,
+      };
+      try {
+        await firstValueFrom(this.authService.register(registerData));
+        toast.success('¡Cuenta creada!', { description: 'Redirigiendo al dashboard...', duration: 2000 });
+        setTimeout(() => this.router.navigate([this.returnUrl]), 1000);
+      } catch (err: unknown) {
+        const anyErr = err as { error?: { message?: string }; message?: string };
+        const msg = anyErr?.error?.message || 'Error al crear la cuenta. Por favor, inténtalo de nuevo.';
+        this.error.set(msg);
+        toast.error('Error de registro', { description: msg, duration: 4000 });
+      } finally {
+        this.loading.set(false);
+      }
+    });
   }
 
   togglePasswordVisibility(): void {
     this.isTogglingPassword = true;
     this.showPassword.update((v) => !v);
     setTimeout(() => {
-      if (this.passwordInput?.nativeElement) {
-        this.passwordInput.nativeElement.focus();
-      }
-      setTimeout(() => {
-        this.isTogglingPassword = false;
-      }, 50);
+      if (this.passwordInput?.nativeElement) this.passwordInput.nativeElement.focus();
+      setTimeout(() => { this.isTogglingPassword = false; }, 50);
     }, 0);
   }
 
@@ -171,36 +156,13 @@ export class RegisterComponent implements OnInit {
     this.isTogglingConfirmPassword = true;
     this.showConfirmPassword.update((v) => !v);
     setTimeout(() => {
-      if (this.confirmPasswordInput?.nativeElement) {
-        this.confirmPasswordInput.nativeElement.focus();
-      }
-      setTimeout(() => {
-        this.isTogglingConfirmPassword = false;
-      }, 50);
+      if (this.confirmPasswordInput?.nativeElement) this.confirmPasswordInput.nativeElement.focus();
+      setTimeout(() => { this.isTogglingConfirmPassword = false; }, 50);
     }, 0);
   }
 
-  private performRegister(): Observable<AuthResponse | null> {
-    const registerData: RegisterRequest = {
-      name: this.registerForm.value.name,
-      email: this.registerForm.value.email,
-      password: this.registerForm.value.password,
-    };
-    return this.authService.register(registerData).pipe(
-      catchError((err) => this.handleRegisterError(err)),
-      finalize(() => this.loading.set(false)),
-    );
-  }
-
-  private handleRegisterError(err: any): Observable<null> {
-    const msg = err?.error?.message || 'Error al crear la cuenta. Por favor, inténtalo de nuevo.';
-    this.error.set(msg);
-    toast.error('Error de registro', { description: msg, duration: 4000 });
-    return of(null);
-  }
-
   resetForm(): void {
-    this.registerForm.reset();
+    this.registerModel.set({ name: '', email: '', password: '', confirmPassword: '' });
     this.submitted.set(false);
     this.error.set('');
     this.isNameFocused.set(false);


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción
Se migra parte del módulo de dispositivos y del layout privado a un enfoque más reactivo con `signal()` y Signal Forms, reemplazando estado mutable y formularios reactivos clásicos en el modal de crear/editar dispositivos.

Los cambios principales incluyen:
- conversión de `isSidebarOpen` en `PrivateLayoutComponent` a `signal<boolean>`,
- actualización del template del layout privado para consumir `isSidebarOpen()` correctamente,
- migración de `DeviceCreateEditModalComponent` desde `ReactiveFormsModule`/`FormGroup` hacia `@angular/forms/signals`,
- uso de `linkedSignal()` para inicializar el modelo del formulario a partir del dispositivo recibido,
- reemplazo de `formControlName` por `[formField]` en los campos del modal,
- centralización de validaciones y mensajes de error en Signal Forms,
- simplificación del submit del modal usando `submit(...)` y `firstValueFrom(...)`,
- actualización de `devices.component.html` para consumir estado basado en señales (`isLoading()`, `bulkMode()`, `bulkStatus()`, `show*Modal()`, `deviceToEdit()`, `deviceToDelete()`).

## ¿Qué tipo de cambio es?
- [ ] Bugfix 🐞
- [ ] Feature ✨
- [x] Refactor 🔧
- [ ] Documentación 📚
- [ ] Otro

## ¿Cómo probar estos cambios?
1. Levantar la aplicación.
2. Verificar en el layout privado que:
   - el sidebar cargue abierto por defecto,
   - el toggle del sidebar siga funcionando correctamente,
   - el estado visual del drawer responda a `isSidebarOpen()`.
3. Ir al módulo de dispositivos.
4. Validar que:
   - el loader siga mostrándose correctamente,
   - el modo masivo siga activándose y desactivándose,
   - el selector de estado masivo funcione correctamente,
   - el botón de actualizar estados masivos solo se habilite cuando haya selección y estado elegido,
   - los modales de crear, editar, eliminar y carga masiva sigan abriendo correctamente.
5. Abrir el modal de crear dispositivo y probar:
   - campo nombre vacío,
   - campo marca vacío,
   - código de barras vacío,
   - código de barras menor a 6 caracteres,
   - campos con solo espacios.
6. Verificar que los mensajes de error se muestren correctamente por campo.
7. Crear un dispositivo nuevo y confirmar que:
   - el submit funciona,
   - se emite el evento `save`,
   - no aparezcan errores inesperados.
8. Editar un dispositivo existente y confirmar que:
   - el formulario se inicializa con los datos del dispositivo,
   - si no hay cambios se muestra la advertencia correspondiente,
   - si hay cambios válidos se guarda correctamente.
9. Probar un dispositivo con `assignmentActive` y confirmar que los campos bloqueados permanezcan deshabilitados.
10. Ejecutar la suite de tests relacionada con layout privado y módulo de dispositivos.

## Checklist
- [x] El código compila y pasa los tests
- [ ] La documentación está actualizada (si aplica)
- [x] No hay warnings nuevos
- [x] Revisé el formato y convenciones de código

## Screenshots (si aplica)
No aplica.

## Issue relacionada
<!-- Si hay issues asociadas, referencia: closes #123 -->

## Notas para el revisor
- El cambio más importante está en `DeviceCreateEditModalComponent`, que ahora usa Signal Forms.
- Se reemplazó el uso de `FormGroup` clásico por `form(...)`, `[formField]`, `submit(...)` y validaciones reactivas con mensajes integrados.
- `linkedSignal()` se usa para recalcular el modelo inicial cuando cambia el dispositivo recibido por input.
- También se alineó `PrivateLayoutComponent` y partes de `devices.component.html` al patrón de señales ya usado en otras áreas del proyecto.
- Aunque el cambio es principalmente de refactor, conviene revisar con atención el flujo de edición y validación del modal de dispositivos.